### PR TITLE
Set up CI workflow with testing

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -1,17 +1,37 @@
-# See https://fly.io/docs/app-guides/continuous-deployment-with-github-actions/
+name: CI
 
-name: Fly Deploy
 on:
   push:
     branches:
-      - publish
+      - '**'
+  pull_request:
+    branches:
+      - main
+
 jobs:
-  deploy:
-    name: Deploy app
+  test:
     runs-on: ubuntu-latest
-    concurrency: deploy-group # optional: ensure only one action runs at a time
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run ok
+
+  deploy:
+    needs: test
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    concurrency: deploy-group
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --remote-only
         env:

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "type": "module",
   "scripts": {
     "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "type-check": "tsc -p tsconfig.app.json --noEmit && tsc -p tsconfig.node.json --noEmit",
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "ok": "npm run format:check && npm run type-check && npm run lint && npm run build && npm test --if-present",
     "preview": "vite preview",
     "up": "npx -y npm-check-updates@latest -u && npm i",
     "knip": "knip --production --fix --allow-remove-files --format --exports"


### PR DESCRIPTION
## Summary
- add `ok` command for format checking, type checking, linting and building
- run the `ok` command in GitHub Actions
- deploy only from pushes to `main` after tests pass

## Testing
- `npm run format:check` *(fails: code style issues found)*
- `npm run lint` *(fails: eslint errors)*
- `npm run type-check` *(fails: tsc errors)*
- `npm run build`