### PR TITLE
Fix TypeScript lint errors

### DIFF
--- a/src/features/chat/ui/NavigationMarker.tsx
+++ b/src/features/chat/ui/NavigationMarker.tsx
@@ -90,10 +90,12 @@ const NavigationMarker: React.FC<NavigationMarkerProps> = ({ item }) => {
         selectHomeRepository()
         break
       case 'repo':
-        // Find the repo by name in a real app
-        const repoId = `repo-${part.value.replace('Repository ', '')}`
-        selectRepository(repoId)
-        break
+        {
+          // Find the repo by name in a real app
+          const repoId = `repo-${part.value.replace('Repository ', '')}`
+          selectRepository(repoId)
+          break
+        }
       case 'branch':
         switchBranch(part.value)
         break

--- a/src/features/home/HomeView.tsx
+++ b/src/features/home/HomeView.tsx
@@ -2,17 +2,18 @@ import React from 'react'
 import { ArrowRight, BarChart2, Clock, Sparkles } from 'lucide-react'
 import { useNavigationStore } from '@/features/navigation/state'
 import { useChatStore } from '@/features/chat/state'
+import type { View } from '@/shared/types'
 
 const HomeView: React.FC = () => {
   const setCurrentView = useNavigationStore((state) => state.setCurrentView)
   const navigateTo = useChatStore((state) => state.navigateTo)
 
-  const handleNavigate = (view: string, title: string, icon: string) => {
-    setCurrentView(view as any)
+  const handleNavigate = (view: View, title: string, icon: string) => {
+    setCurrentView(view)
     navigateTo({
       title,
       icon,
-      view: view as any
+      view
     })
   }
 

--- a/src/features/messages/MessagesView.tsx
+++ b/src/features/messages/MessagesView.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react'
 import { Mail, Search, Filter, Plus, ArrowUpRight, ArrowDownLeft, X, Trash2, Star, StarOff, RefreshCw, Send, PhoneCall, Video } from 'lucide-react'
 import { useMessagesStore } from './state'
 
+type Channel = 'email' | 'whatsapp' | 'status' | 'system' | 'other'
+
 const MessagesView: React.FC = () => {
   const { messages, markAsRead, deleteMessage, toggleStarred, sendMessage } = useMessagesStore()
   
@@ -9,11 +11,16 @@ const MessagesView: React.FC = () => {
   const [selectedMessage, setSelectedMessage] = useState<string | null>(null)
   const [filterType, setFilterType] = useState<'all' | 'incoming' | 'outgoing'>('all')
   const [showComposeModal, setShowComposeModal] = useState(false)
-  const [newMessage, setNewMessage] = useState({
+  const [newMessage, setNewMessage] = useState<{
+    recipient: string
+    subject: string
+    content: string
+    channel: Channel
+  }>({
     recipient: '',
     subject: '',
     content: '',
-    channel: 'email' as 'email' | 'whatsapp' | 'status' | 'system' | 'other'
+    channel: 'email'
   })
 
   // Filter messages based on search term and filters
@@ -357,7 +364,9 @@ const MessagesView: React.FC = () => {
                 <label className="block text-sm font-medium text-gray-700 mb-1">Channel</label>
                 <select
                   value={newMessage.channel}
-                  onChange={(e) => setNewMessage({...newMessage, channel: e.target.value as any})}
+                  onChange={(e) =>
+                    setNewMessage({ ...newMessage, channel: e.target.value as Channel })
+                  }
                   className="w-full border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 >
                   <option value="email">Email</option>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,6 +15,7 @@ Debug.enable('artifact:client:*')
 const url = 'https://web-client-shy-dawn-4057.fly.dev'
 
 declare global {
+  // eslint-disable-next-line no-var
   var artifact: Artifact | undefined
 }
 

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -213,7 +213,7 @@ export interface ProcessLog {
 export interface ProcessMessage {
   id: string
   type: string
-  payload: Record<string, any>
+  payload: Record<string, unknown>
   timestamp: string
   status: 'completed' | 'in-progress' | 'pending' | 'waiting'
   source: string


### PR DESCRIPTION
## Summary
- correct case block scoping in NavigationMarker
- refine types in HomeView navigation handler
- add strict typing for new message state and channel updates
- clarify ProcessMessage payload type
- silence lint rule for global var declaration

## Testing
- `npm run lint`
- `npm run type-check`
