### PR TITLE
Externalize Auth/CDN modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,14 @@
   </head>
   <body>
     <div id="root"></div>
+    <script type="importmap">
+      {
+        "imports": {
+          "@privy-io/react-auth": "https://esm.sh/@privy-io/react-auth",
+          "lucide-react": "https://esm.sh/lucide-react"
+        }
+      }
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,12 @@ import path from 'path'
 export default defineConfig({
   plugins: [react()],
   optimizeDeps: {
-    exclude: ['lucide-react']
+    exclude: ['lucide-react', '@privy-io/react-auth']
+  },
+  build: {
+    rollupOptions: {
+      external: ['lucide-react', '@privy-io/react-auth']
+    }
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- add import maps for `@privy-io/react-auth` and `lucide-react`
- mark both packages as external in Vite

## Testing
- `npm run ok`
