### PR TITLE
Use iframe resizer for account view

### DIFF
--- a/src/features/account/AccountView.tsx
+++ b/src/features/account/AccountView.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
+import { IframeResizer } from '@open-iframe-resizer/react'
 
 const AccountView: React.FC = () => {
   return (
-    <iframe
+    <IframeResizer
       src="https://inverted-capital.github.io/widget-account-panel/"
       title="Account Panel"
       scrolling="no"
+      checkOrigin={false}
       className="w-full h-[calc(100vh-48px)] "
     />
   )


### PR DESCRIPTION
## Summary
- use `IframeResizer` to load the account panel widget

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run ok`
