### PR TITLE
Externalize heavy deps with CDN imports

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,13 @@
       {
         "imports": {
           "@privy-io/react-auth": "https://esm.sh/@privy-io/react-auth",
-          "lucide-react": "https://esm.sh/lucide-react"
+          "@open-iframe-resizer/core": "https://esm.sh/@open-iframe-resizer/core",
+          "@open-iframe-resizer/react": "https://esm.sh/@open-iframe-resizer/react?external=react",
+          "lucide-react": "https://esm.sh/lucide-react?external=react",
+          "react": "https://esm.sh/react",
+          "react-dom": "https://esm.sh/react-dom",
+          "react-dom/client": "https://esm.sh/react-dom/client",
+          "react/jsx-runtime": "https://esm.sh/react/jsx-runtime"
         }
       }
     </script>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,26 +1,58 @@
-import { defineConfig } from 'vite'
+import { defineConfig, Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
+const cdnImports: Record<string, string> = {
+  'lucide-react': 'https://esm.sh/lucide-react?external=react',
+  '@open-iframe-resizer/core': 'https://esm.sh/@open-iframe-resizer/core',
+  '@open-iframe-resizer/react':
+    'https://esm.sh/@open-iframe-resizer/react?external=react',
+  '@privy-io/react-auth':
+    'https://esm.sh/@privy-io/react-auth?external=react,react-dom',
+  react: 'https://esm.sh/react',
+  'react-dom': 'https://esm.sh/react-dom',
+  'react-dom/client': 'https://esm.sh/react-dom/client',
+  'react/jsx-runtime': 'https://esm.sh/react/jsx-runtime'
+}
+
+const externalPackages = Object.keys(cdnImports)
+
+function esmImportMapPlugin(): Plugin {
+  return {
+    name: 'esm-import-map',
+    enforce: 'pre',
+    resolveId(id) {
+      const url = cdnImports[id]
+      if (url) {
+        return { id: url, external: true }
+      }
+      return null
+    }
+  }
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), esmImportMapPlugin()],
   optimizeDeps: {
-    exclude: ['lucide-react', '@privy-io/react-auth']
+    exclude: externalPackages
   },
   build: {
+    sourcemap: true,
     rollupOptions: {
-      external: ['lucide-react', '@privy-io/react-auth']
+      external: externalPackages
     }
   },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src')
+      '@': path.resolve(__dirname, './src'),
+      ...cdnImports
     }
   },
   server: {
     headers: {
       'Cross-Origin-Opener-Policy': 'unsafe-none'
     }
-  }
+  },
+  base: './'
 })


### PR DESCRIPTION
## Summary
- switch to CDN URLs for big deps in Vite config
- configure plugin to map packages to esm.sh
- point import map in index.html to the same CDN URLs
- enable sourcemaps for builds

## Testing
- `npm run -s format:check`
- `npm run -s type-check`
- `npm run -s lint`
- `npm test --if-present`
- `npm run -s build`