### PR TITLE
Fix React hook initialization in production

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,10 +15,10 @@
           "@open-iframe-resizer/core": "https://esm.sh/@open-iframe-resizer/core",
           "@open-iframe-resizer/react": "https://esm.sh/@open-iframe-resizer/react?external=react",
           "lucide-react": "https://esm.sh/lucide-react?external=react",
-          "react": "https://esm.sh/react",
-          "react-dom": "https://esm.sh/react-dom",
-          "react-dom/client": "https://esm.sh/react-dom/client",
-          "react/jsx-runtime": "https://esm.sh/react/jsx-runtime"
+          "react": "https://esm.sh/react@19.1.0",
+          "react-dom": "https://esm.sh/react-dom@19.1.0",
+          "react-dom/client": "https://esm.sh/react-dom@19.1.0/client",
+          "react/jsx-runtime": "https://esm.sh/react@19.1.0/jsx-runtime"
         }
       }
     </script>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
+const REACT_VERSION = '19.1.0'
 const cdnImports: Record<string, string> = {
   'lucide-react': 'https://esm.sh/lucide-react?external=react',
   '@open-iframe-resizer/core': 'https://esm.sh/@open-iframe-resizer/core',
@@ -9,10 +10,10 @@ const cdnImports: Record<string, string> = {
     'https://esm.sh/@open-iframe-resizer/react?external=react',
   '@privy-io/react-auth':
     'https://esm.sh/@privy-io/react-auth?external=react,react-dom',
-  react: 'https://esm.sh/react',
-  'react-dom': 'https://esm.sh/react-dom',
-  'react-dom/client': 'https://esm.sh/react-dom/client',
-  'react/jsx-runtime': 'https://esm.sh/react/jsx-runtime'
+  react: `https://esm.sh/react@${REACT_VERSION}`,
+  'react-dom': `https://esm.sh/react-dom@${REACT_VERSION}`,
+  'react-dom/client': `https://esm.sh/react-dom@${REACT_VERSION}/client`,
+  'react/jsx-runtime': `https://esm.sh/react@${REACT_VERSION}/jsx-runtime`
 }
 
 const externalPackages = Object.keys(cdnImports)


### PR DESCRIPTION
## Summary
- pin React CDN version so production build uses same React as build step

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
