### PR TITLE
Externalize artifact client

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,11 +14,12 @@
           "@privy-io/react-auth": "https://esm.sh/@privy-io/react-auth",
           "@open-iframe-resizer/core": "https://esm.sh/@open-iframe-resizer/core",
           "@open-iframe-resizer/react": "https://esm.sh/@open-iframe-resizer/react?external=react",
+          "@artifact/client": "https://esm.sh/jsr/@artifact/client?external=react",
           "lucide-react": "https://esm.sh/lucide-react?external=react",
-          "react": "https://esm.sh/react@19.1.0",
-          "react-dom": "https://esm.sh/react-dom@19.1.0",
-          "react-dom/client": "https://esm.sh/react-dom@19.1.0/client",
-          "react/jsx-runtime": "https://esm.sh/react@19.1.0/jsx-runtime"
+          "react": "https://esm.sh/react",
+          "react-dom": "https://esm.sh/react-dom",
+          "react-dom/client": "https://esm.sh/react-dom/client",
+          "react/jsx-runtime": "https://esm.sh/react/jsx-runtime"
         }
       }
     </script>

--- a/package.json
+++ b/package.json
@@ -16,16 +16,16 @@
     "knip": "knip --production --fix --allow-remove-files --format --exports"
   },
   "dependencies": {
-    "@artifact/client": "npm:@jsr/artifact__client@^0.0.55",
     "@open-iframe-resizer/react": "^1.6.0",
     "@privy-io/react-auth": "^2.13.1",
     "debug": "^4.4.0",
     "lucide-react": "^0.510.0",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
+    "react": "^19",
+    "react-dom": "^19",
     "zustand": "^5.0.4"
   },
   "devDependencies": {
+    "@artifact/client": "npm:@jsr/artifact__client@^0.0.55",
     "@eslint/js": "^9.26.0",
     "@tailwindcss/postcss": "^4.1.6",
     "@types/react": "^19.1.4",

--- a/src/types/artifact-client.d.ts
+++ b/src/types/artifact-client.d.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare module '@artifact/client' {
+  import type { FC } from 'react'
+
+  export const ArtifactBase: FC<any>
+  export const ArtifactScope: FC<any>
+  export const useIsArtifactReady: () => any
+  export const useArtifact: () => any
+  export interface Artifact {
+    [key: string]: unknown
+  }
+  export interface ArtifactScopeInstance {
+    [key: string]: unknown
+  }
+  export interface RepoScope {
+    repo: { publicKey: string; name: string }
+  }
+  export function useTree(...args: any[]): RepoScope[]
+  export function useScope(...args: any[]): RepoScope | null
+  export function isRepoScope(scope: any): scope is RepoScope
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,6 @@ import { defineConfig, Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
-const REACT_VERSION = '19.1.0'
 const cdnImports: Record<string, string> = {
   'lucide-react': 'https://esm.sh/lucide-react?external=react',
   '@open-iframe-resizer/core': 'https://esm.sh/@open-iframe-resizer/core',
@@ -10,10 +9,11 @@ const cdnImports: Record<string, string> = {
     'https://esm.sh/@open-iframe-resizer/react?external=react',
   '@privy-io/react-auth':
     'https://esm.sh/@privy-io/react-auth?external=react,react-dom',
-  react: `https://esm.sh/react@${REACT_VERSION}`,
-  'react-dom': `https://esm.sh/react-dom@${REACT_VERSION}`,
-  'react-dom/client': `https://esm.sh/react-dom@${REACT_VERSION}/client`,
-  'react/jsx-runtime': `https://esm.sh/react@${REACT_VERSION}/jsx-runtime`
+  '@artifact/client': 'https://esm.sh/jsr/@artifact/client?external=react',
+  react: 'https://esm.sh/react',
+  'react-dom': 'https://esm.sh/react-dom',
+  'react-dom/client': 'https://esm.sh/react-dom/client',
+  'react/jsx-runtime': 'https://esm.sh/react/jsx-runtime'
 }
 
 const externalPackages = Object.keys(cdnImports)


### PR DESCRIPTION
## Summary
- load `@artifact/client` from esm.sh CDN
- bump React imports to unversioned URLs
- allow bundler to resolve artifact client from CDN
- provide local type stubs for `@artifact/client`

## Testing
- `npm run format:check`
- `npm run type-check`
- `npm run lint`
- `npm run build`
