### PR TITLE
Switch to vite-plugin-jspm

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -8,22 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="importmap">
-      {
-        "imports": {
-          "@privy-io/react-auth": "https://esm.sh/@privy-io/react-auth",
-          "@open-iframe-resizer/core": "https://esm.sh/@open-iframe-resizer/core",
-          "@open-iframe-resizer/react": "https://esm.sh/@open-iframe-resizer/react?external=react",
-          "@artifact/client": "https://esm.sh/jsr/@artifact/client@0.0.57?external=react",
-          "@artifact/client/api": "https://esm.sh/jsr/@artifact/client@0.0.57/api?external=react",
-          "lucide-react": "https://esm.sh/lucide-react?external=react",
-          "react": "https://esm.sh/react",
-          "react-dom": "https://esm.sh/react-dom",
-          "react-dom/client": "https://esm.sh/react-dom/client",
-          "react/jsx-runtime": "https://esm.sh/react/jsx-runtime"
-        }
-      }
-    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,55 +1,28 @@
-import { defineConfig, Plugin } from 'vite'
+import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import jspm from 'vite-plugin-jspm'
 
-const cdnImports: Record<string, string> = {
-  'lucide-react': 'https://esm.sh/lucide-react?external=react',
-  '@open-iframe-resizer/core': 'https://esm.sh/@open-iframe-resizer/core',
-  '@open-iframe-resizer/react':
-    'https://esm.sh/@open-iframe-resizer/react?external=react',
-  '@privy-io/react-auth':
-    'https://esm.sh/@privy-io/react-auth?external=react,react-dom',
-  '@artifact/client': 'https://esm.sh/jsr/@artifact/client?external=react',
-  '@artifact/client/api':
-    'https://esm.sh/jsr/@artifact/client@0.0.57/api?external=react',
-  react: 'https://esm.sh/react',
-  'react-dom': 'https://esm.sh/react-dom',
-  'react-dom/client': 'https://esm.sh/react-dom/client',
-  'react/jsx-runtime': 'https://esm.sh/react/jsx-runtime'
-}
-
-const externalPackages = Object.keys(cdnImports)
-
-function esmImportMapPlugin(): Plugin {
-  return {
-    name: 'esm-import-map',
-    enforce: 'pre',
-    resolveId(id: string) {
-      const url = cdnImports[id]
-      if (url) {
-        return { id: url, external: true }
-      }
-      return null
-    }
-  }
-}
-
-// https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), esmImportMapPlugin()],
-  optimizeDeps: {
-    exclude: externalPackages
-  },
+  plugins: [
+    react(),
+    jspm({
+      defaultProvider: 'esm.sh',
+      integrity: true,
+      inputMap: {
+        imports: {
+          '@artifact/client': 'https://esm.sh/jsr/@artifact/client',
+          '@artifact/client/api': 'https://esm.sh/jsr/@artifact/client/api'
+        }
+      }
+    })
+  ],
   build: {
-    sourcemap: true,
-    rollupOptions: {
-      external: externalPackages
-    }
+    sourcemap: true
   },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
-      ...cdnImports
+      '@': path.resolve(__dirname, './src')
     }
   },
   server: {


### PR DESCRIPTION
## Summary
- remove inline import map from `index.html`
- replace custom CDN mapping with `vite-plugin-jspm`
- enable integrity hashes and map @artifact/client through esm.sh

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test` *(fails: Missing script)*