### PR TITLE
Update to new Artifact client

### DIFF
--- a/src/features/account/AccountView.tsx
+++ b/src/features/account/AccountView.tsx
@@ -1,14 +1,22 @@
 import React from 'react'
-import { IframeResizer } from '@open-iframe-resizer/react'
+import { ArtifactFrameHolder } from '@artifact/client/react'
+import { useScope } from '@artifact/client/hooks'
 
 const AccountView: React.FC = () => {
+  const scope = useScope()
   return (
-    <IframeResizer
+    <ArtifactFrameHolder
       src="https://inverted-capital.github.io/widget-account-panel/"
+      target={scope}
+      diffs={[]}
+      access={[]}
+      onSelection={() => {}}
+      onMessage={() => {}}
+      onAccessRequest={() => {}}
+      onNavigateTo={() => {}}
       title="Account Panel"
       scrolling="no"
-      checkOrigin={false}
-      className="w-full h-[calc(100vh-48px)] "
+      className="w-full h-[calc(100vh-48px)]"
     />
   )
 }

--- a/src/features/repos/modals/NewRepositoryModal.tsx
+++ b/src/features/repos/modals/NewRepositoryModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { X, Loader } from 'lucide-react'
 import { useRepoStore } from '../state'
-import { useArtifact } from '@artifact/client'
+import { useArtifact } from '@artifact/client/hooks'
 
 interface NewRepositoryModalProps {
   onClose: () => void

--- a/src/features/repos/ui/RepositoryTree.tsx
+++ b/src/features/repos/ui/RepositoryTree.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { ChevronDown, ChevronRight, FolderGit2, Home, Link } from 'lucide-react'
-import { useTree, ArtifactScope, useScope } from '@artifact/client'
+import { useTree, useScope } from '@artifact/client/hooks'
+import { ArtifactSyncer } from '@artifact/client/react'
 import { isRepoScope, RepoScope } from '@artifact/client/api'
 import { useRepoStore } from '../state'
 
@@ -18,7 +19,7 @@ const RepositoryNode: React.FC<{ scope: RepoScope; home?: boolean }> = ({
   const children = useTree() // children of *this* scope
   const { currentRepoId, selectRepository } = useRepoStore()
 
-  const isSelected = currentRepoId === scope.repo.publicKey
+  const isSelected = currentRepoId === scope.repo
 
   const handleToggle = (e: React.MouseEvent) => {
     e.stopPropagation()
@@ -29,7 +30,7 @@ const RepositoryNode: React.FC<{ scope: RepoScope; home?: boolean }> = ({
 
   const handleSelect = (e: React.MouseEvent) => {
     e.stopPropagation()
-    selectRepository(scope.repo.publicKey)
+    selectRepository(scope.repo)
   }
 
   return (
@@ -55,7 +56,7 @@ const RepositoryNode: React.FC<{ scope: RepoScope; home?: boolean }> = ({
           <div className="mr-2 text-gray-500">
             {home ? <Home size={16} /> : <FolderGit2 size={16} />}
           </div>
-          <div className="truncate font-medium text-sm">{scope.repo.name}</div>
+          <div className="truncate font-medium text-sm">{scope.repo}</div>
           <Link size={14} className="ml-2 text-purple-500" />
         </div>
       </div>
@@ -65,9 +66,9 @@ const RepositoryNode: React.FC<{ scope: RepoScope; home?: boolean }> = ({
           className={`pl-4 border-l border-gray-200 ml-2 ${isOpen ? '' : 'hidden'}`}
         >
           {children.map((child) => (
-            <ArtifactScope key={child.repo.publicKey} {...child}>
+            <ArtifactSyncer key={child.repo} {...child}>
               <RepositoryNode scope={child} />
-            </ArtifactScope>
+            </ArtifactSyncer>
           ))}
         </div>
       )}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,8 @@ import { StrictMode, useEffect, useRef, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './app/App'
 import './index.css'
-import { ArtifactBase, useIsArtifactReady } from '@artifact/client'
+import { ArtifactWeb } from '@artifact/client/react'
+import { useIsArtifactReady } from '@artifact/client/hooks'
 import { type Artifact } from '@artifact/client/api'
 import Debug from 'debug'
 import { PrivyProvider, useIdentityToken, usePrivy } from '@privy-io/react-auth'
@@ -72,7 +73,7 @@ export function AuthenticatedApp() {
   }
 
   return (
-    <ArtifactBase
+    <ArtifactWeb
       did={user.id}
       server={url}
       secureToken={identityToken}
@@ -80,7 +81,7 @@ export function AuthenticatedApp() {
       global
     >
       <LoadingArtifact />
-    </ArtifactBase>
+    </ArtifactWeb>
   )
 }
 


### PR DESCRIPTION
## Summary
- switch AccountView to `ArtifactFrameHolder`
- use new `ArtifactWeb` provider and hooks
- replace deprecated imports for repo views
- adjust repository tree for updated `RepoScope` shape

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683c2864cd04832b854cd1f0b9395359