### PR TITLE
fix artifact loading placeholder

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,6 @@ import { createRoot } from 'react-dom/client'
 import App from './app/App'
 import './index.css'
 import { ArtifactWeb } from '@artifact/client/react'
-import { useIsArtifactReady } from '@artifact/client/hooks'
 import { type Artifact } from '@artifact/client/api'
 import Debug from 'debug'
 import { PrivyProvider, useIdentityToken, usePrivy } from '@privy-io/react-auth'
@@ -79,18 +78,15 @@ export function AuthenticatedApp() {
       secureToken={identityToken}
       onError={onError}
       global
+      placeholder={<LoadingArtifact />}
     >
-      <LoadingArtifact />
+      <App />
     </ArtifactWeb>
   )
 }
 
 export function LoadingArtifact() {
-  const ready = useIsArtifactReady()
-  if (!ready) {
-    return <div>Loading Artifact...</div>
-  }
-  return <App />
+  return <div>Loading Artifact...</div>
 }
 
 export function Boot() {


### PR DESCRIPTION
## Summary
- pass `LoadingArtifact` via `placeholder` prop to `ArtifactWeb`
- simplify `LoadingArtifact` component

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683cceff55cc832b866ebd3173b201b3