### PR TITLE
Implement target scope tracking

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,8 +1,10 @@
 import AppLayout from './AppLayout'
 import useHashRouter from './useHashRouter'
+import useInitTargetScope from '@/shared/useInitTargetScope'
 
 function App() {
   useHashRouter()
+  useInitTargetScope()
   return <AppLayout />
 }
 

--- a/src/features/account/AccountView.tsx
+++ b/src/features/account/AccountView.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
+import { useTargetScopeStore } from '@/shared/targetScope'
 
 const AccountView: React.FC = () => {
-  const scope = useScope()
+  const artifactScope = useScope()
+  const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
   return (
     <ArtifactHolder
       src="https://inverted-capital.github.io/frame-account-panel/"

--- a/src/features/branches/BranchesView.tsx
+++ b/src/features/branches/BranchesView.tsx
@@ -1,16 +1,22 @@
 import React from 'react'
 import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
+import { useTargetScopeStore } from '@/shared/targetScope'
 
 const BranchesView: React.FC = () => {
-  const scope = useScope()
+  const artifactScope = useScope()
+  const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
+  const setScope = useTargetScopeStore((s) => s.setScope)
   return (
     <ArtifactHolder
       src="https://inverted-capital.github.io/frame-branches-panel/"
       target={scope}
       diffs={[]}
       access={[]}
-      onSelection={() => {}}
+      onSelection={(sel) => {
+        const next = sel.scopes[sel.primary]
+        if (next) setScope(next)
+      }}
       onMessage={() => {}}
       onAccessRequest={() => {}}
       onNavigateTo={() => {}}

--- a/src/features/chat/ChatsView.tsx
+++ b/src/features/chat/ChatsView.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
+import { useTargetScopeStore } from '@/shared/targetScope'
 
 const ChatsView: React.FC = () => {
-  const scope = useScope()
+  const artifactScope = useScope()
+  const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
   return (
     <ArtifactHolder
       src="https://inverted-capital.github.io/frame-chats-panel/"

--- a/src/features/customers/CustomersView.tsx
+++ b/src/features/customers/CustomersView.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
+import { useTargetScopeStore } from '@/shared/targetScope'
 
 const CustomersView: React.FC = () => {
-  const scope = useScope()
+  const artifactScope = useScope()
+  const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
   return (
     <ArtifactHolder
       src="https://inverted-capital.github.io/frame-customers-panel/"

--- a/src/features/files/FilesView.tsx
+++ b/src/features/files/FilesView.tsx
@@ -1,16 +1,22 @@
 import React from 'react'
 import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
+import { useTargetScopeStore } from '@/shared/targetScope'
 
 const FilesView: React.FC = () => {
-  const scope = useScope()
+  const artifactScope = useScope()
+  const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
+  const setScope = useTargetScopeStore((s) => s.setScope)
   return (
     <ArtifactHolder
       src="https://inverted-capital.github.io/frame-files-panel/"
       target={scope}
       diffs={[]}
       access={[]}
-      onSelection={() => {}}
+      onSelection={(sel) => {
+        const next = sel.scopes[sel.primary]
+        if (next) setScope(next)
+      }}
       onMessage={() => {}}
       onAccessRequest={() => {}}
       onNavigateTo={() => {}}

--- a/src/features/help/HelpView.tsx
+++ b/src/features/help/HelpView.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
+import { useTargetScopeStore } from '@/shared/targetScope'
 
 const HelpView: React.FC = () => {
-  const scope = useScope()
+  const artifactScope = useScope()
+  const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
   return (
     <ArtifactHolder
       src="https://inverted-capital.github.io/frame-help-panel/"

--- a/src/features/home/HomeView.tsx
+++ b/src/features/home/HomeView.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
+import { useTargetScopeStore } from '@/shared/targetScope'
 
 const HomeView: React.FC = () => {
-  const scope = useScope()
+  const artifactScope = useScope()
+  const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
   return (
     <ArtifactHolder
       src="https://inverted-capital.github.io/frame-home-panel/"

--- a/src/features/innovations/InnovationsView.tsx
+++ b/src/features/innovations/InnovationsView.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
+import { useTargetScopeStore } from '@/shared/targetScope'
 
 const InnovationsView: React.FC = () => {
-  const scope = useScope()
+  const artifactScope = useScope()
+  const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
   return (
     <ArtifactHolder
       src="https://inverted-capital.github.io/frame-innovations-panel/"

--- a/src/features/messages/MessagesView.tsx
+++ b/src/features/messages/MessagesView.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
+import { useTargetScopeStore } from '@/shared/targetScope'
 
 const MessagesView: React.FC = () => {
-  const scope = useScope()
+  const artifactScope = useScope()
+  const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
   return (
     <ArtifactHolder
       src="https://inverted-capital.github.io/frame-messages-panel/"

--- a/src/features/napps/NappsView.tsx
+++ b/src/features/napps/NappsView.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
+import { useTargetScopeStore } from '@/shared/targetScope'
 
 const NappsView: React.FC = () => {
-  const scope = useScope()
+  const artifactScope = useScope()
+  const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
   return (
     <ArtifactHolder
       src="https://inverted-capital.github.io/frame-napps-panel/"

--- a/src/features/processes/ProcessesView.tsx
+++ b/src/features/processes/ProcessesView.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
+import { useTargetScopeStore } from '@/shared/targetScope'
 
 const ProcessesView: React.FC = () => {
-  const scope = useScope()
+  const artifactScope = useScope()
+  const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
   return (
     <ArtifactHolder
       src="https://inverted-capital.github.io/frame-processes-panel/"

--- a/src/features/repos/ReposView.tsx
+++ b/src/features/repos/ReposView.tsx
@@ -1,16 +1,22 @@
 import React from 'react'
 import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
+import { useTargetScopeStore } from '@/shared/targetScope'
 
 const ReposView: React.FC = () => {
-  const scope = useScope()
+  const artifactScope = useScope()
+  const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
+  const setScope = useTargetScopeStore((s) => s.setScope)
   return (
     <ArtifactHolder
       src="https://inverted-capital.github.io/frame-repos-panel/"
       target={scope}
       diffs={[]}
       access={[]}
-      onSelection={() => {}}
+      onSelection={(sel) => {
+        const next = sel.scopes[sel.primary]
+        if (next) setScope(next)
+      }}
       onMessage={() => {}}
       onAccessRequest={() => {}}
       onNavigateTo={() => {}}

--- a/src/features/settings/SettingsView.tsx
+++ b/src/features/settings/SettingsView.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
+import { useTargetScopeStore } from '@/shared/targetScope'
 
 const SettingsView: React.FC = () => {
-  const scope = useScope()
+  const artifactScope = useScope()
+  const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
   return (
     <ArtifactHolder
       src="https://inverted-capital.github.io/frame-settings-panel/"

--- a/src/features/transcludes/TranscludesView.tsx
+++ b/src/features/transcludes/TranscludesView.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
+import { useTargetScopeStore } from '@/shared/targetScope'
 
 const TranscludesView: React.FC = () => {
-  const scope = useScope()
+  const artifactScope = useScope()
+  const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
   return (
     <ArtifactHolder
       src="https://inverted-capital.github.io/frame-transcludes-panel/"

--- a/src/features/weather/WeatherView.tsx
+++ b/src/features/weather/WeatherView.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
+import { useTargetScopeStore } from '@/shared/targetScope'
 
 const WeatherView: React.FC = () => {
-  const scope = useScope()
+  const artifactScope = useScope()
+  const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
   return (
     <ArtifactHolder
       src="https://inverted-capital.github.io/frame-weather-panel/"

--- a/src/shared/targetScope.ts
+++ b/src/shared/targetScope.ts
@@ -1,0 +1,12 @@
+import { create } from 'zustand'
+import type { Scope } from '@artifact/client/api'
+
+interface TargetScopeState {
+  scope: Scope | null
+  setScope: (scope: Scope) => void
+}
+
+export const useTargetScopeStore = create<TargetScopeState>((set) => ({
+  scope: null,
+  setScope: (scope) => set({ scope })
+}))

--- a/src/shared/useInitTargetScope.ts
+++ b/src/shared/useInitTargetScope.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react'
+import { useBaseArtifact } from '@artifact/client/hooks'
+import { useTargetScopeStore } from './targetScope'
+
+export default function useInitTargetScope() {
+  const artifact = useBaseArtifact()
+  const scope = useTargetScopeStore((s) => s.scope)
+  const setScope = useTargetScopeStore((s) => s.setScope)
+
+  useEffect(() => {
+    if (scope) return
+    let cancelled = false
+    ;(async () => {
+      const [first] = await artifact.super.ls()
+      if (!cancelled && first) {
+        setScope(first)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [artifact, scope, setScope])
+}


### PR DESCRIPTION
## Summary
- track the selected artifact scope in a new store
- default the scope with `artifact.super.ls()`
- expose `useInitTargetScope` hook and use it in the app
- pass the selected scope to all panels
- update repo, branch and files panels to update the target scope on selection

## Testing
- `npm run format:check`
- `npm run type-check`
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c0e1e4224832bad338770b56eeff5