### PR TITLE
Add Agents and Events navigation

### DIFF
--- a/src/app/CanvasContainer.tsx
+++ b/src/app/CanvasContainer.tsx
@@ -16,6 +16,8 @@ import NappsView from '@/features/napps/NappsView'
 import TranscludesView from '@/features/transcludes/TranscludesView'
 import MessagesView from '@/features/messages/MessagesView'
 import ProcessesView from '@/features/processes/ProcessesView'
+import AgentsView from '@/features/agents/AgentsView'
+import EventsView from '@/features/events/EventsView'
 
 const CanvasContainer: React.FC = () => {
   const currentView = useNavigationStore((state) => state.currentView)
@@ -32,6 +34,10 @@ const CanvasContainer: React.FC = () => {
     switch (view) {
       case 'chats':
         return <ChatsView />
+      case 'agents':
+        return <AgentsView />
+      case 'events':
+        return <EventsView />
       case 'files':
         return <FilesView />
       case 'repos':

--- a/src/app/Sidebar.tsx
+++ b/src/app/Sidebar.tsx
@@ -13,7 +13,9 @@ import {
   Clipboard,
   GitBranch,
   Mail,
-  Cpu
+  Cpu,
+  Bot,
+  Calendar
 } from 'lucide-react'
 import { SidebarItem } from '@/shared/types'
 import { useChatStore } from '@/features/chat/state'
@@ -32,13 +34,15 @@ const Sidebar: React.FC = () => {
   const sidebarItems: SidebarItem[] = [
     { icon: 'Home', label: 'Home', view: 'home' },
     { icon: 'MessageSquare', label: 'Chats', view: 'chats' },
+    { icon: 'Bot', label: 'Agents', view: 'agents' },
     { icon: 'Clipboard', label: 'Transcludes', view: 'transcludes' },
-    { icon: 'Mail', label: 'Agentic Messages', view: 'messages' },
+    { icon: 'Calendar', label: 'Events', view: 'events' },
     { icon: 'FolderGit2', label: 'Repos', view: 'repos' },
     { icon: 'GitBranch', label: 'Branches', view: 'branches' },
     { icon: 'Folder', label: 'Files', view: 'files' },
     { icon: 'Package', label: 'Napps', view: 'napps' },
     { icon: 'Cpu', label: 'Processes', view: 'processes' },
+    { icon: 'Calendar', label: 'Events', view: 'events' },
     { icon: 'Settings', label: 'Settings', view: 'settings' },
     { icon: 'Lightbulb', label: 'Innovations', view: 'innovations' },
     { icon: 'User', label: 'Account', view: 'account' },
@@ -76,6 +80,10 @@ const Sidebar: React.FC = () => {
         return <Mail size={20} />
       case 'Cpu':
         return <Cpu size={20} />
+      case 'Bot':
+        return <Bot size={20} />
+      case 'Calendar':
+        return <Calendar size={20} />
       default:
         return <MessageSquare size={20} />
     }
@@ -98,12 +106,12 @@ const Sidebar: React.FC = () => {
     return currentView === item.view && !item.action
   }
 
-  // Group 1: User-specific items (Home, Chats, Transcludes, Messages)
-  const userGroup = sidebarItems.slice(0, 4)
-  // Group 2: Transclude/scope selection items (Repos, Branches, Files, Napps, Processes, Settings)
-  const transcludeSelectorGroup = sidebarItems.slice(4, 11)
+  // Group 1: User-specific items (Home, Chats, Agents, Transcludes, Events)
+  const userGroup = sidebarItems.slice(0, 5)
+  // Group 2: Transclude/scope selection items (Repos, Branches, Files, Napps, Processes, Events, Settings, Innovations)
+  const transcludeSelectorGroup = sidebarItems.slice(5, 13)
   // Group 3: Account and help items
-  const accountGroup = sidebarItems.slice(11)
+  const accountGroup = sidebarItems.slice(13)
 
   return (
     <nav className="w-16 bg-gray-900 text-white flex flex-col items-center py-6">

--- a/src/features/agents/AgentsView.tsx
+++ b/src/features/agents/AgentsView.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const AgentsView: React.FC = () => {
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-semibold mb-2">Agents</h2>
+      <p>Placeholder for Agents frame.</p>
+    </div>
+  )
+}
+
+export default AgentsView

--- a/src/features/events/EventsView.tsx
+++ b/src/features/events/EventsView.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+const EventsView: React.FC = () => {
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-semibold mb-2">Events</h2>
+      <p>Placeholder for Events frame.</p>
+    </div>
+  )
+}
+
+export default EventsView

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,7 +1,9 @@
 type Role = 'user' | 'assistant' | 'system'
 type MessageType = 'text' | 'navigation' | 'file' | 'code'
 export type View =
+  | 'agents'
   | 'chats'
+  | 'events'
   | 'files'
   | 'repos'
   | 'branches'


### PR DESCRIPTION
## Summary
- create placeholder AgentsView and EventsView
- add `agents` and `events` views
- update sidebar to show new buttons and update group slices
- wire up new views in CanvasContainer

## Testing
- `npm run ok`


------
https://chatgpt.com/codex/tasks/task_e_684cb7b9752c832b9ea0525b10fa9c74