### PR TITLE
Fix repeated home scope fetch

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode, useEffect, useRef, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './app/App'
+import HomeScopeProvider from '@/shared/HomeScopeProvider'
 import './index.css'
 import { ArtifactWeb } from '@artifact/client/react'
 import { type Artifact } from '@artifact/client/api'
@@ -80,7 +81,9 @@ export function AuthenticatedApp() {
       global
       placeholder={<LoadingArtifact />}
     >
-      <App />
+      <HomeScopeProvider>
+        <App />
+      </HomeScopeProvider>
     </ArtifactWeb>
   )
 }

--- a/src/shared/HomeScopeProvider.tsx
+++ b/src/shared/HomeScopeProvider.tsx
@@ -1,0 +1,33 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+import { useBaseArtifact } from '@artifact/client/hooks'
+import type { Scope } from '@artifact/client/api'
+
+export const HomeScopeContext = createContext<Scope | null>(null)
+
+export const HomeScopeProvider: React.FC<{ children: React.ReactNode }> = ({
+  children
+}) => {
+  const artifact = useBaseArtifact()
+  const [scope, setScope] = useState<Scope | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const [first] = await artifact.super.ls()
+      if (!cancelled) setScope(first ?? null)
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [artifact])
+
+  return (
+    <HomeScopeContext.Provider value={scope}>{children}</HomeScopeContext.Provider>
+  )
+}
+
+export function useHomeScope(): Scope | null {
+  return useContext(HomeScopeContext)
+}
+
+export default HomeScopeProvider

--- a/src/shared/useHomeScope.ts
+++ b/src/shared/useHomeScope.ts
@@ -1,21 +1,2 @@
-import { useEffect, useState } from 'react'
-import { useBaseArtifact } from '@artifact/client/hooks'
-import type { Scope } from '@artifact/client/api'
-
-export default function useHomeScope(): Scope | null {
-  const artifact = useBaseArtifact()
-  const [homeScope, setHomeScope] = useState<Scope | null>(null)
-
-  useEffect(() => {
-    let cancelled = false
-    ;(async () => {
-      const [first] = await artifact.super.ls()
-      if (!cancelled) setHomeScope(first ?? null)
-    })()
-    return () => {
-      cancelled = true
-    }
-  }, [artifact])
-
-  return homeScope
-}
+import { useHomeScope } from './HomeScopeProvider'
+export default useHomeScope


### PR DESCRIPTION
## Summary
- cache home scope result in `useHomeScope` to reuse across instances

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test --if-present`


------
https://chatgpt.com/codex/tasks/task_e_684d3d0a538c832b910028a0f104f5bb