### PR TITLE
Fix event sidebar selection

### DIFF
--- a/src/app/CanvasContainer.tsx
+++ b/src/app/CanvasContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { useNavigationStore } from '@/shared/navigationState'
 import type { View } from '@/shared/types'
 import ChatsView from '@/frames/ChatsView'
@@ -21,6 +21,7 @@ import EventsView from '@/frames/EventsView'
 const allViews: View[] = [
   'agents',
   'chats',
+  'home-events',
   'events',
   'files',
   'repos',
@@ -51,6 +52,8 @@ const CanvasContainer: React.FC = () => {
         return <ChatsView />
       case 'agents':
         return <AgentsView />
+      case 'home-events':
+        return <EventsView />
       case 'events':
         return <EventsView />
       case 'files':

--- a/src/app/Sidebar.tsx
+++ b/src/app/Sidebar.tsx
@@ -36,7 +36,7 @@ const Sidebar: React.FC = () => {
     { icon: 'MessageSquare', label: 'Chats', view: 'chats' },
     { icon: 'UsersRound', label: 'Agents', view: 'agents' },
     { icon: 'CloudUpload', label: 'Transcludes', view: 'transcludes' },
-    { icon: 'Zap', label: 'Events', view: 'events' },
+    { icon: 'Zap', label: 'Events', view: 'home-events' },
     { icon: 'FolderGit2', label: 'Repos', view: 'repos' },
     { icon: 'GitBranch', label: 'Branches', view: 'branches' },
     { icon: 'Folder', label: 'Files', view: 'files' },

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -3,6 +3,7 @@ type MessageType = 'text' | 'navigation' | 'file' | 'code'
 export type View =
   | 'agents'
   | 'chats'
+  | 'home-events'
   | 'events'
   | 'files'
   | 'repos'


### PR DESCRIPTION
## Summary
- add unique `home-events` view to represent Events for the Home scope
- wire Sidebar and CanvasContainer to use `home-events`

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Property 'access' does not exist on type...)*
- `npm run build`
- `npm test --if-present`

------
https://chatgpt.com/codex/tasks/task_e_684d4e1aa528832b9325d8922b283092