### PR TITLE
Convert EventsView to artifact frame

### DIFF
--- a/src/frames/AccountView.tsx
+++ b/src/frames/AccountView.tsx
@@ -11,7 +11,7 @@ const AccountView: React.FC = () => {
       src="https://inverted-capital.github.io/frame-account-panel/"
       target={scope}
       diffs={[]}
-      access={[]}
+      expandedAccess={[]}
       onSelection={() => {}}
       onMessage={() => {}}
       onAccessRequest={() => {}}

--- a/src/frames/AgentsView.tsx
+++ b/src/frames/AgentsView.tsx
@@ -11,7 +11,7 @@ const BranchesView: React.FC = () => {
       src="https://inverted-capital.github.io/frame-agents-panel/"
       target={scope}
       diffs={[]}
-      access={[]}
+      expandedAccess={[]}
       onSelection={(sel) => {
         console.log(sel)
       }}

--- a/src/frames/ChatsView.tsx
+++ b/src/frames/ChatsView.tsx
@@ -11,7 +11,7 @@ const ChatsView: React.FC = () => {
       src="https://inverted-capital.github.io/frame-chats-panel/"
       target={scope}
       diffs={[]}
-      access={[]}
+      expandedAccess={[]}
       onSelection={() => {}}
       onMessage={() => {}}
       onAccessRequest={() => {}}

--- a/src/frames/CustomersView.tsx
+++ b/src/frames/CustomersView.tsx
@@ -11,7 +11,7 @@ const CustomersView: React.FC = () => {
       src="https://inverted-capital.github.io/frame-customers-panel/"
       target={scope}
       diffs={[]}
-      access={[]}
+      expandedAccess={[]}
       onSelection={() => {}}
       onMessage={() => {}}
       onAccessRequest={() => {}}

--- a/src/frames/EventsView.tsx
+++ b/src/frames/EventsView.tsx
@@ -1,11 +1,36 @@
 import React from 'react'
+import { ArtifactHolder } from '@artifact/client/react'
+import { useScope } from '@artifact/client/hooks'
+import type { Scope } from '@artifact/client/api'
+import { useTargetScopeStore } from '@/shared/targetScope'
+import useHomeScope from '@/shared/useHomeScope'
 
-const EventsView: React.FC = () => {
+interface EventsViewProps {
+  home?: boolean
+}
+
+const EventsView: React.FC<EventsViewProps> = ({ home }) => {
+  const homeScope = useHomeScope()
+  const artifactScope = useScope()
+  const targetScope = useTargetScopeStore((s) => s.scope) ?? artifactScope
+
+  const scope = (home ? homeScope : targetScope) as Scope
+
+  if (home && !homeScope) return <div>Loading home scope...</div>
+
   return (
-    <div className="p-4">
-      <h2 className="text-xl font-semibold mb-2">Events</h2>
-      <p>Placeholder for Events frame.</p>
-    </div>
+    <ArtifactHolder
+      src="https://inverted-capital.github.io/frame-events-panel/"
+      target={scope}
+      diffs={[]}
+      expandedAccess={[]}
+      onSelection={() => {}}
+      onMessage={() => {}}
+      onAccessRequest={() => {}}
+      onNavigateTo={() => {}}
+      title="Events Panel"
+      className="w-full h-[calc(100vh-48px)]"
+    />
   )
 }
 

--- a/src/frames/FilesView.tsx
+++ b/src/frames/FilesView.tsx
@@ -12,7 +12,7 @@ const FilesView: React.FC = () => {
       src="https://inverted-capital.github.io/frame-files-panel/"
       target={scope}
       diffs={[]}
-      access={[]}
+      expandedAccess={[]}
       onSelection={(sel) => {
         const next = sel.scopes[sel.primary]
         if (next) setScope(next)

--- a/src/frames/HelpView.tsx
+++ b/src/frames/HelpView.tsx
@@ -11,7 +11,7 @@ const HelpView: React.FC = () => {
       src="https://inverted-capital.github.io/frame-help-panel/"
       target={scope}
       diffs={[]}
-      access={[]}
+      expandedAccess={[]}
       onSelection={() => {}}
       onMessage={() => {}}
       onAccessRequest={() => {}}

--- a/src/frames/HomeView.tsx
+++ b/src/frames/HomeView.tsx
@@ -11,7 +11,7 @@ const HomeView: React.FC = () => {
       src="https://inverted-capital.github.io/frame-home-panel/"
       target={scope}
       diffs={[]}
-      access={[]}
+      expandedAccess={[]}
       onSelection={() => {}}
       onMessage={() => {}}
       onAccessRequest={() => {}}

--- a/src/frames/InnovationsView.tsx
+++ b/src/frames/InnovationsView.tsx
@@ -11,7 +11,7 @@ const InnovationsView: React.FC = () => {
       src="https://inverted-capital.github.io/frame-innovations-panel/"
       target={scope}
       diffs={[]}
-      access={[]}
+      expandedAccess={[]}
       onSelection={() => {}}
       onMessage={() => {}}
       onAccessRequest={() => {}}

--- a/src/frames/NappsView.tsx
+++ b/src/frames/NappsView.tsx
@@ -11,7 +11,7 @@ const NappsView: React.FC = () => {
       src="https://inverted-capital.github.io/frame-napps-panel/"
       target={scope}
       diffs={[]}
-      access={[]}
+      expandedAccess={[]}
       onSelection={() => {}}
       onMessage={() => {}}
       onAccessRequest={() => {}}

--- a/src/frames/ProcessesView.tsx
+++ b/src/frames/ProcessesView.tsx
@@ -11,7 +11,7 @@ const ProcessesView: React.FC = () => {
       src="https://inverted-capital.github.io/frame-processes-panel/"
       target={scope}
       diffs={[]}
-      access={[]}
+      expandedAccess={[]}
       onSelection={() => {}}
       onMessage={() => {}}
       onAccessRequest={() => {}}

--- a/src/frames/ReposView.tsx
+++ b/src/frames/ReposView.tsx
@@ -12,7 +12,7 @@ const ReposView: React.FC = () => {
       src="https://inverted-capital.github.io/frame-repos-panel/"
       target={scope}
       diffs={[]}
-      access={[]}
+      expandedAccess={[]}
       onSelection={(sel) => {
         const next = sel.scopes[sel.primary]
         if (next) setScope(next)

--- a/src/frames/SettingsView.tsx
+++ b/src/frames/SettingsView.tsx
@@ -11,7 +11,7 @@ const SettingsView: React.FC = () => {
       src="https://inverted-capital.github.io/frame-settings-panel/"
       target={scope}
       diffs={[]}
-      access={[]}
+      expandedAccess={[]}
       onSelection={() => {}}
       onMessage={() => {}}
       onAccessRequest={() => {}}

--- a/src/frames/TranscludesView.tsx
+++ b/src/frames/TranscludesView.tsx
@@ -11,7 +11,7 @@ const TranscludesView: React.FC = () => {
       src="https://inverted-capital.github.io/frame-transcludes-panel/"
       target={scope}
       diffs={[]}
-      access={[]}
+      expandedAccess={[]}
       onSelection={() => {}}
       onMessage={() => {}}
       onAccessRequest={() => {}}

--- a/src/frames/WeatherView.tsx
+++ b/src/frames/WeatherView.tsx
@@ -11,7 +11,7 @@ const WeatherView: React.FC = () => {
       src="https://inverted-capital.github.io/frame-weather-panel/"
       target={scope}
       diffs={[]}
-      access={[]}
+      expandedAccess={[]}
       onSelection={() => {}}
       onMessage={() => {}}
       onAccessRequest={() => {}}


### PR DESCRIPTION
## Summary
- update all frames to use `expandedAccess` prop
- convert `EventsView` into an artifact holder with optional `home` target

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d5300e664832b9b470200b159c881