### PR TITLE
Fix react-refresh lint warnings

### DIFF
--- a/src/shared/HomeScopeProvider.tsx
+++ b/src/shared/HomeScopeProvider.tsx
@@ -1,8 +1,7 @@
-import React, { createContext, useContext, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useBaseArtifact } from '@artifact/client/hooks'
 import type { Scope } from '@artifact/client/api'
-
-export const HomeScopeContext = createContext<Scope | null>(null)
+import HomeScopeContext from './homeScopeContext'
 
 export const HomeScopeProvider: React.FC<{ children: React.ReactNode }> = ({
   children
@@ -26,10 +25,6 @@ export const HomeScopeProvider: React.FC<{ children: React.ReactNode }> = ({
       {children}
     </HomeScopeContext.Provider>
   )
-}
-
-export function useHomeScope(): Scope | null {
-  return useContext(HomeScopeContext)
 }
 
 export default HomeScopeProvider

--- a/src/shared/homeScopeContext.ts
+++ b/src/shared/homeScopeContext.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react'
+import type { Scope } from '@artifact/client/api'
+
+const HomeScopeContext = createContext<Scope | null>(null)
+export default HomeScopeContext

--- a/src/shared/useHomeScope.ts
+++ b/src/shared/useHomeScope.ts
@@ -1,2 +1,7 @@
-import { useHomeScope } from './HomeScopeProvider'
-export default useHomeScope
+import { useContext } from 'react'
+import type { Scope } from '@artifact/client/api'
+import HomeScopeContext from './homeScopeContext'
+
+export default function useHomeScope(): Scope | null {
+  return useContext(HomeScopeContext)
+}


### PR DESCRIPTION
## Summary
- fix lint warnings about only-export-components
- move context to its own file and implement hook separately

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_684d5814d3a0832b999b3194224b5b4f