### PR TITLE
Refactor lucide imports

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,7 +4,8 @@ import Sidebar from './Sidebar'
 import StateBoard from './StateBoard'
 import { ChatHistory, ChatInput } from '@/chat'
 import { useState } from 'react'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+import ChevronLeft from 'lucide-react/dist/esm/icons/chevron-left'
+import ChevronRight from 'lucide-react/dist/esm/icons/chevron-right'
 
 function App() {
   useHashRouter()

--- a/src/app/Sidebar.tsx
+++ b/src/app/Sidebar.tsx
@@ -1,22 +1,20 @@
 import React from 'react'
-import {
-  Home,
-  MessageSquare,
-  Folder,
-  FolderGit2,
-  LogOut,
-  HelpCircle,
-  User,
-  Lightbulb,
-  Settings,
-  Package,
-  CloudUpload,
-  GitBranch,
-  Mail,
-  Cpu,
-  UsersRound,
-  Zap
-} from 'lucide-react'
+import Home from 'lucide-react/dist/esm/icons/home'
+import MessageSquare from 'lucide-react/dist/esm/icons/message-square'
+import Folder from 'lucide-react/dist/esm/icons/folder'
+import FolderGit2 from 'lucide-react/dist/esm/icons/folder-git-2'
+import LogOut from 'lucide-react/dist/esm/icons/log-out'
+import HelpCircle from 'lucide-react/dist/esm/icons/help-circle'
+import User from 'lucide-react/dist/esm/icons/user'
+import Lightbulb from 'lucide-react/dist/esm/icons/lightbulb'
+import Settings from 'lucide-react/dist/esm/icons/settings'
+import Package from 'lucide-react/dist/esm/icons/package'
+import CloudUpload from 'lucide-react/dist/esm/icons/cloud-upload'
+import GitBranch from 'lucide-react/dist/esm/icons/git-branch'
+import Mail from 'lucide-react/dist/esm/icons/mail'
+import Cpu from 'lucide-react/dist/esm/icons/cpu'
+import UsersRound from 'lucide-react/dist/esm/icons/users-round'
+import Zap from 'lucide-react/dist/esm/icons/zap'
 import { SidebarItem } from '@/shared/types'
 import { useChatStore } from '@/chat/chatState'
 import { useNavigationStore } from '@/shared/navigationState'

--- a/src/app/StateBoard.tsx
+++ b/src/app/StateBoard.tsx
@@ -3,13 +3,11 @@ import { useNavigationStore } from '@/shared/navigationState'
 import type { View } from '@/shared/types'
 import type { Scope } from '@artifact/client/api'
 import { useTargetScopeStore } from '@/shared/targetScope'
-import {
-  Target,
-  Settings,
-  ChevronDown,
-  ChevronLeft,
-  ChevronRight
-} from 'lucide-react'
+import Target from 'lucide-react/dist/esm/icons/target'
+import Settings from 'lucide-react/dist/esm/icons/settings'
+import ChevronDown from 'lucide-react/dist/esm/icons/chevron-down'
+import ChevronLeft from 'lucide-react/dist/esm/icons/chevron-left'
+import ChevronRight from 'lucide-react/dist/esm/icons/chevron-right'
 import ChatsView from '@/frames/ChatsView'
 import FilesView from '@/frames/FilesView'
 import ReposView from '@/frames/ReposView'

--- a/src/chat/ChatHistory.tsx
+++ b/src/chat/ChatHistory.tsx
@@ -2,14 +2,12 @@ import React from 'react'
 import { useChatStore } from './chatState'
 import ChatMessage from './ChatMessage'
 import NavigationMarker from './NavigationMarker'
-import {
-  MessageSquare,
-  Settings,
-  Search,
-  Plus,
-  Maximize2,
-  Minimize2
-} from 'lucide-react'
+import MessageSquare from 'lucide-react/dist/esm/icons/message-square'
+import Settings from 'lucide-react/dist/esm/icons/settings'
+import Search from 'lucide-react/dist/esm/icons/search'
+import Plus from 'lucide-react/dist/esm/icons/plus'
+import Maximize2 from 'lucide-react/dist/esm/icons/maximize-2'
+import Minimize2 from 'lucide-react/dist/esm/icons/minimize-2'
 import { ChatMessage as ChatMessageType, NavigationItem } from '@/shared/types'
 
 type TimelineItem =

--- a/src/chat/ChatInput.tsx
+++ b/src/chat/ChatInput.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react'
-import { Send, Paperclip, Mic } from 'lucide-react'
+import Send from 'lucide-react/dist/esm/icons/send'
+import Paperclip from 'lucide-react/dist/esm/icons/paperclip'
+import Mic from 'lucide-react/dist/esm/icons/mic'
 import { useChatStore } from './chatState'
 
 const ChatInput: React.FC = () => {

--- a/src/chat/NavigationMarker.tsx
+++ b/src/chat/NavigationMarker.tsx
@@ -1,12 +1,10 @@
 import React from 'react'
-import {
-  ChevronDown,
-  ChevronRight,
-  Code,
-  FileText,
-  Home,
-  GitBranch
-} from 'lucide-react'
+import ChevronDown from 'lucide-react/dist/esm/icons/chevron-down'
+import ChevronRight from 'lucide-react/dist/esm/icons/chevron-right'
+import Code from 'lucide-react/dist/esm/icons/code'
+import FileText from 'lucide-react/dist/esm/icons/file-text'
+import Home from 'lucide-react/dist/esm/icons/home'
+import GitBranch from 'lucide-react/dist/esm/icons/git-branch'
 import { NavigationItem } from '@/shared/types'
 import { useChatStore } from './chatState'
 import { useNavigationStore } from '@/shared/navigationState'


### PR DESCRIPTION
## Summary
- import individual icons from lucide-react instead of the main barrel

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f79e22a04832badd169933bd43553