### PR TITLE
Fix npm run ok

### DIFF
--- a/src/lucide-react.d.ts
+++ b/src/lucide-react.d.ts
@@ -1,0 +1,1 @@
+declare module 'lucide-react/dist/esm/icons/*'


### PR DESCRIPTION
## Summary
- declare types for lucide-react icons so tsc passes

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_684f812d21d0832b8d21befce067c84a