### PR TITLE
Add diagnostic frame option

### DIFF
--- a/diagnotic.html
+++ b/diagnotic.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Diagnostic Frame</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/diagnotic.tsx"></script>
+  </body>
+</html>

--- a/src/app/StateBoard.tsx
+++ b/src/app/StateBoard.tsx
@@ -141,6 +141,8 @@ const StateBoard: React.FC = () => {
 
   const setFrameSrc = useFrameSrcStore((s) => s.setSrc)
   const getFrameSrc = useFrameSrcStore((s) => s.getSrc)
+  const toggleDiagnostic = useFrameSrcStore((s) => s.toggleDiagnostic)
+  const diagnosticEnabled = useFrameSrcStore((s) => s.diagnostic[currentView])
 
   const reloadCurrentView = () => {
     setReloadKeys((prev) => ({
@@ -243,6 +245,18 @@ const StateBoard: React.FC = () => {
                     className="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
                   >
                     Edit Frame Source
+                  </button>
+                  <button
+                    onClick={() => {
+                      toggleDiagnostic(currentView)
+                      reloadCurrentView()
+                      setShowSettingsMenu(false)
+                    }}
+                    className="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                  >
+                    {diagnosticEnabled
+                      ? 'Disable Diagnostic'
+                      : 'Enable Diagnostic'}
                   </button>
                 </div>
               )}

--- a/src/diagnotic.tsx
+++ b/src/diagnotic.tsx
@@ -1,0 +1,119 @@
+import { StrictMode, useEffect, useState } from 'react'
+import { createRoot } from 'react-dom/client'
+import { ArtifactFrame } from '@artifact/client/react'
+import { useFrame, useArtifact } from '@artifact/client/hooks'
+
+interface FileMeta {
+  path: string
+}
+
+function Diagnostic() {
+  const frame = useFrame()
+  const artifact = useArtifact()
+  const [files, setFiles] = useState<FileMeta[]>()
+  const [branches, setBranches] = useState<string[]>()
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    if (!artifact) return
+    let active = true
+    const updateFiles = async () => {
+      const list = await artifact.files.read.ls('.')
+      if (active) setFiles(list)
+    }
+    const watchFiles = async () => {
+      for await (const event of artifact.files.read.watch('.')) {
+        void event
+        if (!active) break
+        await updateFiles()
+      }
+    }
+    updateFiles()
+    watchFiles()
+    return () => {
+      active = false
+    }
+  }, [artifact])
+
+  useEffect(() => {
+    if (!artifact) return
+    let active = true
+    const updateBranches = async () => {
+      const list = await artifact.repo.branches.ls()
+      if (active) setBranches(list)
+    }
+    const watchBranches = async () => {
+      for await (const ev of artifact.repo.branches.watch()) {
+        void ev
+        if (!active) break
+        await updateBranches()
+      }
+    }
+    updateBranches()
+    watchBranches()
+    return () => {
+      active = false
+    }
+  }, [artifact])
+
+  const addFile = () => {
+    if (!artifact) return
+    const path = `diagnostic-${Date.now()}-${count}.txt`
+    setCount((c) => c + 1)
+    artifact.files.write.text(path, 'diagnostic file')
+  }
+
+  return (
+    <div style={{ fontFamily: 'monospace', padding: 10 }}>
+      <h2>Diagnostic Frame</h2>
+      <h3>Props</h3>
+      <pre>
+        {JSON.stringify(
+          {
+            target: frame.target,
+            diffs: frame.diffs,
+            expandedAccess: frame.expandedAccess,
+            selection: frame.selection
+          },
+          null,
+          2
+        )}
+      </pre>
+      <h3>Scope</h3>
+      <pre>{JSON.stringify(artifact?.scope, null, 2)}</pre>
+      <h3>Branches</h3>
+      <pre>{JSON.stringify(branches, null, 2)}</pre>
+      <h3>Files</h3>
+      <pre>{JSON.stringify(files, null, 2)}</pre>
+      <div style={{ marginTop: 10 }}>
+        <button onClick={() => frame.onSelection?.(frame.target)}>
+          onSelection
+        </button>
+        <button onClick={() => frame.onMessage?.({ type: 'diagnostic' })}>
+          onMessage
+        </button>
+        <button onClick={() => frame.onAccessRequest?.([frame.target])}>
+          onAccessRequest
+        </button>
+        <button onClick={() => frame.onNavigateTo?.(frame.target)}>
+          onNavigateTo
+        </button>
+        <button onClick={addFile}>Add File</button>
+      </div>
+    </div>
+  )
+}
+
+function Boot() {
+  return (
+    <ArtifactFrame>
+      <Diagnostic />
+    </ArtifactFrame>
+  )
+}
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <Boot />
+  </StrictMode>
+)

--- a/src/shared/frameSrc.ts
+++ b/src/shared/frameSrc.ts
@@ -23,15 +23,28 @@ const DEFAULT_SRCS: Record<View, string> = {
 
 interface FrameSrcState {
   srcs: Partial<Record<View, string>>
+  diagnostic: Partial<Record<View, boolean>>
   setSrc: (view: View, src: string) => void
+  setDiagnostic: (view: View, enabled: boolean) => void
+  toggleDiagnostic: (view: View) => void
   getSrc: (view: View) => string
 }
 
 export const useFrameSrcStore = create<FrameSrcState>((set, get) => ({
   srcs: {},
+  diagnostic: {},
   setSrc: (view, src) =>
     set((state) => ({ srcs: { ...state.srcs, [view]: src } })),
-  getSrc: (view) => get().srcs[view] ?? DEFAULT_SRCS[view]
+  setDiagnostic: (view, enabled) =>
+    set((state) => ({ diagnostic: { ...state.diagnostic, [view]: enabled } })),
+  toggleDiagnostic: (view) =>
+    set((state) => ({
+      diagnostic: { ...state.diagnostic, [view]: !state.diagnostic[view] }
+    })),
+  getSrc: (view) =>
+    get().diagnostic[view]
+      ? '/diagnotic.html'
+      : (get().srcs[view] ?? DEFAULT_SRCS[view])
 }))
 
 export function defaultSrcFor(view: View): string {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,12 @@ export default defineConfig({
   base: './',
   build: {
     sourcemap: true,
-    minify: false
+    minify: false,
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        diagnotic: path.resolve(__dirname, 'diagnotic.html')
+      }
+    }
   }
 })


### PR DESCRIPTION
## Summary
- implement diagnostic frame and page
- enable toggling diagnostic mode per view
- expose toggle in StateBoard settings
- configure vite to build and serve the new page

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint`
- `npm run build`
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_6854a3e93a00832ba284ce043f49c9af