### PR TITLE
Add frame source reset

### DIFF
--- a/src/app/StateBoard.tsx
+++ b/src/app/StateBoard.tsx
@@ -141,6 +141,7 @@ const StateBoard: React.FC = () => {
 
   const setFrameSrc = useFrameSrcStore((s) => s.setSrc)
   const getFrameSrc = useFrameSrcStore((s) => s.getSrc)
+  const resetFrameSrc = useFrameSrcStore((s) => s.resetSrc)
   const toggleDiagnostic = useFrameSrcStore((s) => s.toggleDiagnostic)
   const diagnosticEnabled = useFrameSrcStore((s) => s.diagnostic[currentView])
 
@@ -245,6 +246,16 @@ const StateBoard: React.FC = () => {
                     className="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
                   >
                     Edit Frame Source
+                  </button>
+                  <button
+                    onClick={() => {
+                      resetFrameSrc(currentView)
+                      reloadCurrentView()
+                      setShowSettingsMenu(false)
+                    }}
+                    className="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
+                  >
+                    Reset Frame Source
                   </button>
                   <button
                     onClick={() => {

--- a/src/shared/frameSrc.ts
+++ b/src/shared/frameSrc.ts
@@ -25,6 +25,10 @@ interface FrameSrcState {
   srcs: Partial<Record<View, string>>
   diagnostic: Partial<Record<View, boolean>>
   setSrc: (view: View, src: string) => void
+  /**
+   * Reset a frame source back to its default value
+   */
+  resetSrc: (view: View) => void
   setDiagnostic: (view: View, enabled: boolean) => void
   toggleDiagnostic: (view: View) => void
   getSrc: (view: View) => string
@@ -34,9 +38,17 @@ const DIAGNOSTIC_PATH = `${import.meta.env.BASE_URL}diagnotic.html`
 
 export const useFrameSrcStore = create<FrameSrcState>((set, get) => ({
   srcs: {},
-  diagnostic: {},
+  diagnostic: Object.fromEntries(
+    Object.keys(DEFAULT_SRCS).map((k) => [k, true])
+  ) as Partial<Record<View, boolean>>,
   setSrc: (view, src) =>
     set((state) => ({ srcs: { ...state.srcs, [view]: src } })),
+  resetSrc: (view) =>
+    set((state) => {
+      const next = { ...state.srcs }
+      delete next[view]
+      return { srcs: next }
+    }),
   setDiagnostic: (view, enabled) =>
     set((state) => ({ diagnostic: { ...state.diagnostic, [view]: enabled } })),
   toggleDiagnostic: (view) =>


### PR DESCRIPTION
## Summary
- default all views to diagnostic mode
- allow resetting a panel back to its default source
- expose Reset Frame Source action in the settings menu

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_6854adbd8c48832b9b2370847dbf1d7c