### PR TITLE
Implement global diagnostic toggle

### DIFF
--- a/src/app/StateBoard.tsx
+++ b/src/app/StateBoard.tsx
@@ -8,6 +8,7 @@ import Settings from 'lucide-react/dist/esm/icons/settings'
 import ChevronDown from 'lucide-react/dist/esm/icons/chevron-down'
 import ChevronLeft from 'lucide-react/dist/esm/icons/chevron-left'
 import ChevronRight from 'lucide-react/dist/esm/icons/chevron-right'
+import Bug from 'lucide-react/dist/esm/icons/bug'
 import ChatsView from '@/frames/ChatsView'
 import FilesView from '@/frames/FilesView'
 import ReposView from '@/frames/ReposView'
@@ -143,13 +144,23 @@ const StateBoard: React.FC = () => {
   const getFrameSrc = useFrameSrcStore((s) => s.getSrc)
   const resetFrameSrc = useFrameSrcStore((s) => s.resetSrc)
   const toggleDiagnostic = useFrameSrcStore((s) => s.toggleDiagnostic)
-  const diagnosticEnabled = useFrameSrcStore((s) => s.diagnostic[currentView])
+  const diagnosticEnabled = useFrameSrcStore((s) => s.diagnostic)
 
   const reloadCurrentView = () => {
     setReloadKeys((prev) => ({
       ...prev,
       [currentView]: (prev[currentView] ?? 0) + 1
     }))
+  }
+
+  const reloadAllViews = () => {
+    setReloadKeys((prev) => {
+      const next = { ...prev }
+      visitedViews.forEach((view) => {
+        next[view] = (next[view] ?? 0) + 1
+      })
+      return next
+    })
   }
 
   const handleEditSrc = () => {
@@ -257,21 +268,21 @@ const StateBoard: React.FC = () => {
                   >
                     Reset Frame Source
                   </button>
-                  <button
-                    onClick={() => {
-                      toggleDiagnostic(currentView)
-                      reloadCurrentView()
-                      setShowSettingsMenu(false)
-                    }}
-                    className="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50"
-                  >
-                    {diagnosticEnabled
-                      ? 'Disable Diagnostic'
-                      : 'Enable Diagnostic'}
-                  </button>
                 </div>
               )}
             </div>
+            <button
+              onClick={() => {
+                toggleDiagnostic()
+                reloadAllViews()
+              }}
+              className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-white hover:shadow-sm rounded-md border border-transparent hover:border-gray-200 transition-all duration-150"
+              title={
+                diagnosticEnabled ? 'Disable Diagnostic' : 'Enable Diagnostic'
+              }
+            >
+              <Bug size={14} />
+            </button>
           </div>
         </div>
       </div>

--- a/src/shared/frameSrc.ts
+++ b/src/shared/frameSrc.ts
@@ -23,14 +23,14 @@ const DEFAULT_SRCS: Record<View, string> = {
 
 interface FrameSrcState {
   srcs: Partial<Record<View, string>>
-  diagnostic: Partial<Record<View, boolean>>
+  diagnostic: boolean
   setSrc: (view: View, src: string) => void
   /**
    * Reset a frame source back to its default value
    */
   resetSrc: (view: View) => void
-  setDiagnostic: (view: View, enabled: boolean) => void
-  toggleDiagnostic: (view: View) => void
+  setDiagnostic: (enabled: boolean) => void
+  toggleDiagnostic: () => void
   getSrc: (view: View) => string
 }
 
@@ -38,9 +38,7 @@ const DIAGNOSTIC_PATH = `${import.meta.env.BASE_URL}diagnotic.html`
 
 export const useFrameSrcStore = create<FrameSrcState>((set, get) => ({
   srcs: {},
-  diagnostic: Object.fromEntries(
-    Object.keys(DEFAULT_SRCS).map((k) => [k, true])
-  ) as Partial<Record<View, boolean>>,
+  diagnostic: true,
   setSrc: (view, src) =>
     set((state) => ({ srcs: { ...state.srcs, [view]: src } })),
   resetSrc: (view) =>
@@ -49,14 +47,10 @@ export const useFrameSrcStore = create<FrameSrcState>((set, get) => ({
       delete next[view]
       return { srcs: next }
     }),
-  setDiagnostic: (view, enabled) =>
-    set((state) => ({ diagnostic: { ...state.diagnostic, [view]: enabled } })),
-  toggleDiagnostic: (view) =>
-    set((state) => ({
-      diagnostic: { ...state.diagnostic, [view]: !state.diagnostic[view] }
-    })),
+  setDiagnostic: (enabled) => set({ diagnostic: enabled }),
+  toggleDiagnostic: () => set((state) => ({ diagnostic: !state.diagnostic })),
   getSrc: (view) =>
-    get().diagnostic[view]
+    get().diagnostic
       ? DIAGNOSTIC_PATH
       : (get().srcs[view] ?? DEFAULT_SRCS[view])
 }))


### PR DESCRIPTION
## Summary
- implement diagnostic flag as a single boolean in `frameSrc` store
- reload all frames when toggling diagnostic
- move diagnostic toggle to the header next to the settings button

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_6854f22ff13c832baebf040a2b652fb0