### PR TITLE
Preserve normal frames when diagnostics toggled

### DIFF
--- a/src/app/StateBoard.tsx
+++ b/src/app/StateBoard.tsx
@@ -153,16 +153,6 @@ const StateBoard: React.FC = () => {
     }))
   }
 
-  const reloadAllViews = () => {
-    setReloadKeys((prev) => {
-      const next = { ...prev }
-      visitedViews.forEach((view) => {
-        next[view] = (next[view] ?? 0) + 1
-      })
-      return next
-    })
-  }
-
   const handleEditSrc = () => {
     const current = getFrameSrc(currentView)
     const next = window.prompt('Enter frame source URL', current)
@@ -274,7 +264,6 @@ const StateBoard: React.FC = () => {
             <button
               onClick={() => {
                 toggleDiagnostic()
-                reloadAllViews()
               }}
               className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-white hover:shadow-sm rounded-md border border-transparent hover:border-gray-200 transition-all duration-150"
               title={

--- a/src/frames/AccountView.tsx
+++ b/src/frames/AccountView.tsx
@@ -1,23 +1,13 @@
 import React from 'react'
-import { ArtifactHolder } from '@artifact/client/react'
 import useHomeScope from '@/shared/useHomeScope'
-import useSelectionUpdater from '@/shared/useSelectionUpdater'
-import { useFrameSrcStore } from '@/shared/frameSrc'
+import FrameWithDiagnostic from '@/shared/FrameWithDiagnostic'
 
 const AccountView: React.FC = () => {
   const scope = useHomeScope()
-  const onSelection = useSelectionUpdater()
-  const src = useFrameSrcStore((s) => s.getSrc('account'))
   if (!scope) return <div className="p-6">Loading home scope...</div>
 
   return (
-    <ArtifactHolder
-      src={src}
-      target={scope}
-      onSelection={onSelection}
-      title="Account Panel"
-      className="w-full h-[calc(100vh-48px)]"
-    />
+    <FrameWithDiagnostic view="account" scope={scope} title="Account Panel" />
   )
 }
 

--- a/src/frames/BranchesView.tsx
+++ b/src/frames/BranchesView.tsx
@@ -1,24 +1,14 @@
 import React from 'react'
-import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
 import { useTargetScopeStore } from '@/shared/targetScope'
-import useSelectionUpdater from '@/shared/useSelectionUpdater'
-import { useFrameSrcStore } from '@/shared/frameSrc'
+import FrameWithDiagnostic from '@/shared/FrameWithDiagnostic'
 
 const BranchesView: React.FC = () => {
   const artifactScope = useScope()
   const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
-  const onSelection = useSelectionUpdater()
-  const src = useFrameSrcStore((s) => s.getSrc('branches'))
   if (!scope) return <div className="p-6">No target scope</div>
   return (
-    <ArtifactHolder
-      src={src}
-      target={scope}
-      onSelection={onSelection}
-      title="Branches Panel"
-      className="w-full h-[calc(100vh-48px)]"
-    />
+    <FrameWithDiagnostic view="branches" scope={scope} title="Branches Panel" />
   )
 }
 

--- a/src/frames/ChatsView.tsx
+++ b/src/frames/ChatsView.tsx
@@ -1,25 +1,13 @@
 import React from 'react'
-import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
 import { useTargetScopeStore } from '@/shared/targetScope'
-import useSelectionUpdater from '@/shared/useSelectionUpdater'
-import { useFrameSrcStore } from '@/shared/frameSrc'
+import FrameWithDiagnostic from '@/shared/FrameWithDiagnostic'
 
 const ChatsView: React.FC = () => {
   const artifactScope = useScope()
   const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
-  const onSelection = useSelectionUpdater()
-  const src = useFrameSrcStore((s) => s.getSrc('chats'))
   if (!scope) return <div className="p-6">No target scope</div>
-  return (
-    <ArtifactHolder
-      src={src}
-      target={scope}
-      onSelection={onSelection}
-      title="Chats Panel"
-      className="w-full h-[calc(100vh-48px)]"
-    />
-  )
+  return <FrameWithDiagnostic view="chats" scope={scope} title="Chats Panel" />
 }
 
 export default ChatsView

--- a/src/frames/ContactsView.tsx
+++ b/src/frames/ContactsView.tsx
@@ -1,23 +1,13 @@
 import React from 'react'
-import { ArtifactHolder } from '@artifact/client/react'
 import useHomeScope from '@/shared/useHomeScope'
-import useSelectionUpdater from '@/shared/useSelectionUpdater'
-import { useFrameSrcStore } from '@/shared/frameSrc'
+import FrameWithDiagnostic from '@/shared/FrameWithDiagnostic'
 
 const ContactsView: React.FC = () => {
   const scope = useHomeScope()
-  const onSelection = useSelectionUpdater()
-  const src = useFrameSrcStore((s) => s.getSrc('contacts'))
   if (!scope) return <div className="p-6">Loading home scope...</div>
 
   return (
-    <ArtifactHolder
-      src={src}
-      target={scope}
-      onSelection={onSelection}
-      title="Contacts Panel"
-      className="w-full h-[calc(100vh-48px)]"
-    />
+    <FrameWithDiagnostic view="contacts" scope={scope} title="Contacts Panel" />
   )
 }
 

--- a/src/frames/CustomersView.tsx
+++ b/src/frames/CustomersView.tsx
@@ -1,23 +1,17 @@
 import React from 'react'
-import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
 import { useTargetScopeStore } from '@/shared/targetScope'
-import useSelectionUpdater from '@/shared/useSelectionUpdater'
-import { useFrameSrcStore } from '@/shared/frameSrc'
+import FrameWithDiagnostic from '@/shared/FrameWithDiagnostic'
 
 const CustomersView: React.FC = () => {
   const artifactScope = useScope()
   const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
-  const onSelection = useSelectionUpdater()
-  const src = useFrameSrcStore((s) => s.getSrc('customers'))
   if (!scope) return <div className="p-6">No target scope</div>
   return (
-    <ArtifactHolder
-      src={src}
-      target={scope}
-      onSelection={onSelection}
+    <FrameWithDiagnostic
+      view="customers"
+      scope={scope}
       title="Customers Panel"
-      className="w-full h-[calc(100vh-48px)]"
     />
   )
 }

--- a/src/frames/EventsView.tsx
+++ b/src/frames/EventsView.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
-import { ArtifactHolder } from '@artifact/client/react'
 import { useTargetScopeStore } from '@/shared/targetScope'
 import useHomeScope from '@/shared/useHomeScope'
-import useSelectionUpdater from '@/shared/useSelectionUpdater'
-import { useFrameSrcStore } from '@/shared/frameSrc'
+import FrameWithDiagnostic from '@/shared/FrameWithDiagnostic'
 
 interface EventsViewProps {
   home?: boolean
@@ -12,8 +10,6 @@ interface EventsViewProps {
 const EventsView: React.FC<EventsViewProps> = ({ home }) => {
   const homeScope = useHomeScope()
   const targetScope = useTargetScopeStore((s) => s.scope)
-  const onSelection = useSelectionUpdater()
-  const src = useFrameSrcStore((s) => s.getSrc(home ? 'home-events' : 'events'))
 
   const scope = home ? homeScope : targetScope
 
@@ -25,12 +21,10 @@ const EventsView: React.FC<EventsViewProps> = ({ home }) => {
   if (!scope) return <div className="p-6">No scope</div>
 
   return (
-    <ArtifactHolder
-      src={src}
-      target={scope}
-      onSelection={onSelection}
+    <FrameWithDiagnostic
+      view={home ? 'home-events' : 'events'}
+      scope={scope}
       title="Events Panel"
-      className="w-full h-[calc(100vh-48px)]"
     />
   )
 }

--- a/src/frames/FilesView.tsx
+++ b/src/frames/FilesView.tsx
@@ -1,25 +1,13 @@
 import React from 'react'
-import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
 import { useTargetScopeStore } from '@/shared/targetScope'
-import useSelectionUpdater from '@/shared/useSelectionUpdater'
-import { useFrameSrcStore } from '@/shared/frameSrc'
+import FrameWithDiagnostic from '@/shared/FrameWithDiagnostic'
 
 const FilesView: React.FC = () => {
   const artifactScope = useScope()
   const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
-  const onSelection = useSelectionUpdater()
-  const src = useFrameSrcStore((s) => s.getSrc('files'))
   if (!scope) return <div className="p-6">No target scope</div>
-  return (
-    <ArtifactHolder
-      src={src}
-      target={scope}
-      onSelection={onSelection}
-      title="Files Panel"
-      className="w-full h-[calc(100vh-48px)]"
-    />
-  )
+  return <FrameWithDiagnostic view="files" scope={scope} title="Files Panel" />
 }
 
 export default FilesView

--- a/src/frames/HelpView.tsx
+++ b/src/frames/HelpView.tsx
@@ -1,24 +1,12 @@
 import React from 'react'
-import { ArtifactHolder } from '@artifact/client/react'
 import useHomeScope from '@/shared/useHomeScope'
-import useSelectionUpdater from '@/shared/useSelectionUpdater'
-import { useFrameSrcStore } from '@/shared/frameSrc'
+import FrameWithDiagnostic from '@/shared/FrameWithDiagnostic'
 
 const HelpView: React.FC = () => {
   const scope = useHomeScope()
-  const onSelection = useSelectionUpdater()
-  const src = useFrameSrcStore((s) => s.getSrc('help'))
   if (!scope) return <div className="p-6">Loading home scope...</div>
 
-  return (
-    <ArtifactHolder
-      src={src}
-      target={scope}
-      onSelection={onSelection}
-      title="Help Panel"
-      className="w-full h-[calc(100vh-48px)]"
-    />
-  )
+  return <FrameWithDiagnostic view="help" scope={scope} title="Help Panel" />
 }
 
 export default HelpView

--- a/src/frames/HomeView.tsx
+++ b/src/frames/HomeView.tsx
@@ -1,24 +1,12 @@
 import React from 'react'
-import { ArtifactHolder } from '@artifact/client/react'
 import useHomeScope from '@/shared/useHomeScope'
-import useSelectionUpdater from '@/shared/useSelectionUpdater'
-import { useFrameSrcStore } from '@/shared/frameSrc'
+import FrameWithDiagnostic from '@/shared/FrameWithDiagnostic'
 
 const HomeView: React.FC = () => {
   const scope = useHomeScope()
-  const onSelection = useSelectionUpdater()
-  const src = useFrameSrcStore((s) => s.getSrc('home'))
   if (!scope) return <div className="p-6">Loading home scope...</div>
 
-  return (
-    <ArtifactHolder
-      src={src}
-      target={scope}
-      onSelection={onSelection}
-      title="Home Panel"
-      className="w-full h-[calc(100vh-48px)]"
-    />
-  )
+  return <FrameWithDiagnostic view="home" scope={scope} title="Home Panel" />
 }
 
 export default HomeView

--- a/src/frames/InnovationsView.tsx
+++ b/src/frames/InnovationsView.tsx
@@ -1,23 +1,17 @@
 import React from 'react'
-import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
 import { useTargetScopeStore } from '@/shared/targetScope'
-import useSelectionUpdater from '@/shared/useSelectionUpdater'
-import { useFrameSrcStore } from '@/shared/frameSrc'
+import FrameWithDiagnostic from '@/shared/FrameWithDiagnostic'
 
 const InnovationsView: React.FC = () => {
   const artifactScope = useScope()
   const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
-  const onSelection = useSelectionUpdater()
-  const src = useFrameSrcStore((s) => s.getSrc('innovations'))
   if (!scope) return <div className="p-6">No target scope</div>
   return (
-    <ArtifactHolder
-      src={src}
-      target={scope}
-      onSelection={onSelection}
+    <FrameWithDiagnostic
+      view="innovations"
+      scope={scope}
       title="Innovations Panel"
-      className="w-full h-[calc(100vh-48px)]"
     />
   )
 }

--- a/src/frames/NappsView.tsx
+++ b/src/frames/NappsView.tsx
@@ -1,25 +1,13 @@
 import React from 'react'
-import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
 import { useTargetScopeStore } from '@/shared/targetScope'
-import useSelectionUpdater from '@/shared/useSelectionUpdater'
-import { useFrameSrcStore } from '@/shared/frameSrc'
+import FrameWithDiagnostic from '@/shared/FrameWithDiagnostic'
 
 const NappsView: React.FC = () => {
   const artifactScope = useScope()
   const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
-  const onSelection = useSelectionUpdater()
-  const src = useFrameSrcStore((s) => s.getSrc('napps'))
   if (!scope) return <div className="p-6">No target scope</div>
-  return (
-    <ArtifactHolder
-      src={src}
-      target={scope}
-      onSelection={onSelection}
-      title="Napps Panel"
-      className="w-full h-[calc(100vh-48px)]"
-    />
-  )
+  return <FrameWithDiagnostic view="napps" scope={scope} title="Napps Panel" />
 }
 
 export default NappsView

--- a/src/frames/ProcessesView.tsx
+++ b/src/frames/ProcessesView.tsx
@@ -1,23 +1,17 @@
 import React from 'react'
-import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
 import { useTargetScopeStore } from '@/shared/targetScope'
-import useSelectionUpdater from '@/shared/useSelectionUpdater'
-import { useFrameSrcStore } from '@/shared/frameSrc'
+import FrameWithDiagnostic from '@/shared/FrameWithDiagnostic'
 
 const ProcessesView: React.FC = () => {
   const artifactScope = useScope()
   const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
-  const onSelection = useSelectionUpdater()
-  const src = useFrameSrcStore((s) => s.getSrc('processes'))
   if (!scope) return <div className="p-6">No target scope</div>
   return (
-    <ArtifactHolder
-      src={src}
-      target={scope}
-      onSelection={onSelection}
+    <FrameWithDiagnostic
+      view="processes"
+      scope={scope}
       title="Processes Panel"
-      className="w-full h-[calc(100vh-48px)]"
     />
   )
 }

--- a/src/frames/ReposView.tsx
+++ b/src/frames/ReposView.tsx
@@ -1,23 +1,17 @@
 import React from 'react'
-import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
 import { useTargetScopeStore } from '@/shared/targetScope'
-import useSelectionUpdater from '@/shared/useSelectionUpdater'
-import { useFrameSrcStore } from '@/shared/frameSrc'
+import FrameWithDiagnostic from '@/shared/FrameWithDiagnostic'
 
 const ReposView: React.FC = () => {
   const artifactScope = useScope()
   const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
-  const onSelection = useSelectionUpdater()
-  const src = useFrameSrcStore((s) => s.getSrc('repos'))
   if (!scope) return <div className="p-6">No target scope</div>
   return (
-    <ArtifactHolder
-      src={src}
-      target={scope}
-      onSelection={onSelection}
+    <FrameWithDiagnostic
+      view="repos"
+      scope={scope}
       title="Repositories Panel"
-      className="w-full h-[calc(100vh-48px)]"
     />
   )
 }

--- a/src/frames/SettingsView.tsx
+++ b/src/frames/SettingsView.tsx
@@ -1,24 +1,14 @@
 import React from 'react'
-import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
 import { useTargetScopeStore } from '@/shared/targetScope'
-import useSelectionUpdater from '@/shared/useSelectionUpdater'
-import { useFrameSrcStore } from '@/shared/frameSrc'
+import FrameWithDiagnostic from '@/shared/FrameWithDiagnostic'
 
 const SettingsView: React.FC = () => {
   const artifactScope = useScope()
   const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
-  const onSelection = useSelectionUpdater()
-  const src = useFrameSrcStore((s) => s.getSrc('settings'))
   if (!scope) return <div className="p-6">No target scope</div>
   return (
-    <ArtifactHolder
-      src={src}
-      target={scope}
-      onSelection={onSelection}
-      title="Settings Panel"
-      className="w-full h-[calc(100vh-48px)]"
-    />
+    <FrameWithDiagnostic view="settings" scope={scope} title="Settings Panel" />
   )
 }
 

--- a/src/frames/TranscludesView.tsx
+++ b/src/frames/TranscludesView.tsx
@@ -1,23 +1,17 @@
 import React from 'react'
-import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
 import { useTargetScopeStore } from '@/shared/targetScope'
-import useSelectionUpdater from '@/shared/useSelectionUpdater'
-import { useFrameSrcStore } from '@/shared/frameSrc'
+import FrameWithDiagnostic from '@/shared/FrameWithDiagnostic'
 
 const TranscludesView: React.FC = () => {
   const artifactScope = useScope()
   const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
-  const onSelection = useSelectionUpdater()
-  const src = useFrameSrcStore((s) => s.getSrc('transcludes'))
   if (!scope) return <div className="p-6">No target scope</div>
   return (
-    <ArtifactHolder
-      src={src}
-      target={scope}
-      onSelection={onSelection}
+    <FrameWithDiagnostic
+      view="transcludes"
+      scope={scope}
       title="Transcludes Panel"
-      className="w-full h-[calc(100vh-48px)]"
     />
   )
 }

--- a/src/frames/WeatherView.tsx
+++ b/src/frames/WeatherView.tsx
@@ -1,24 +1,14 @@
 import React from 'react'
-import { ArtifactHolder } from '@artifact/client/react'
 import { useScope } from '@artifact/client/hooks'
 import { useTargetScopeStore } from '@/shared/targetScope'
-import useSelectionUpdater from '@/shared/useSelectionUpdater'
-import { useFrameSrcStore } from '@/shared/frameSrc'
+import FrameWithDiagnostic from '@/shared/FrameWithDiagnostic'
 
 const WeatherView: React.FC = () => {
   const artifactScope = useScope()
   const scope = useTargetScopeStore((s) => s.scope) ?? artifactScope
-  const onSelection = useSelectionUpdater()
-  const src = useFrameSrcStore((s) => s.getSrc('weather'))
   if (!scope) return <div className="p-6">No target scope</div>
   return (
-    <ArtifactHolder
-      src={src}
-      target={scope}
-      onSelection={onSelection}
-      title="Weather Panel"
-      className="w-full h-[calc(100vh-48px)]"
-    />
+    <FrameWithDiagnostic view="weather" scope={scope} title="Weather Panel" />
   )
 }
 

--- a/src/shared/FrameWithDiagnostic.tsx
+++ b/src/shared/FrameWithDiagnostic.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { ArtifactHolder } from '@artifact/client/react'
+import type { Scope } from '@artifact/client/api'
+import type { View } from '@/shared/types'
+import {
+  DIAGNOSTIC_PATH,
+  useRegularSrc,
+  useFrameSrcStore
+} from '@/shared/frameSrc'
+import useSelectionUpdater from '@/shared/useSelectionUpdater'
+
+interface Props {
+  view: View
+  scope: Scope
+  title: string
+}
+
+const FrameWithDiagnostic: React.FC<Props> = ({ view, scope, title }) => {
+  const diagnostic = useFrameSrcStore((s) => s.diagnostic)
+  const src = useRegularSrc(view)
+  const onSelection = useSelectionUpdater()
+
+  return (
+    <div className="w-full h-[calc(100vh-48px)]">
+      <ArtifactHolder
+        src={src}
+        target={scope}
+        onSelection={onSelection}
+        title={title}
+        className={diagnostic ? 'hidden w-full h-full' : 'w-full h-full'}
+      />
+      {diagnostic && (
+        <ArtifactHolder
+          src={DIAGNOSTIC_PATH}
+          target={scope}
+          onSelection={onSelection}
+          title="Diagnostic Panel"
+          className="w-full h-full"
+        />
+      )}
+    </div>
+  )
+}
+
+export default FrameWithDiagnostic

--- a/src/shared/frameSrc.ts
+++ b/src/shared/frameSrc.ts
@@ -34,7 +34,11 @@ interface FrameSrcState {
   getSrc: (view: View) => string
 }
 
-const DIAGNOSTIC_PATH = `${import.meta.env.BASE_URL}diagnotic.html`
+export const DIAGNOSTIC_PATH = `${import.meta.env.BASE_URL}diagnotic.html`
+
+export function useRegularSrc(view: View): string {
+  return useFrameSrcStore((s) => s.srcs[view] ?? DEFAULT_SRCS[view])
+}
 
 export const useFrameSrcStore = create<FrameSrcState>((set, get) => ({
   srcs: {},


### PR DESCRIPTION
## Summary
- keep normal frames mounted when diagnostics toggle is used
- factor diagnostic wrapper into `FrameWithDiagnostic`
- export diagnostic path and helper hook
- stop reloading all views when enabling diagnostics

## Testing
- `npm run ok` *(fails: build step unable to finish)*

------
https://chatgpt.com/codex/tasks/task_e_685878c7b398832b8fb8417ebcf61e3a