### PR TITLE
Fix stateboard overflow

### DIFF
--- a/src/app/StateBoard.tsx
+++ b/src/app/StateBoard.tsx
@@ -278,7 +278,7 @@ const StateBoard: React.FC = () => {
 
       {/* View Content */}
       {showStateBoard && (
-        <div className="flex-1 overflow-y-auto bg-gray-50">
+        <div className="flex-1 overflow-hidden w-full h-full bg-gray-50">
           {visitedViews.map((view) => (
             <div
               key={`${view}-${reloadKeys[view] ?? 0}`}


### PR DESCRIPTION
## Summary
- change stateboard view content container to fill available space and hide overflow

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_685a657a84c4832b95148aeafa0d4a7f