### PR TITLE
Fix Diagnostic Frame overflow

### DIFF
--- a/diagnotic.html
+++ b/diagnotic.html
@@ -4,6 +4,17 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Diagnostic Frame</title>
+    <style>
+      html,
+      body,
+      #root {
+        height: 100%;
+        margin: 0;
+      }
+      #root > div {
+        height: 100%;
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/src/diagnotic.tsx
+++ b/src/diagnotic.tsx
@@ -55,6 +55,7 @@ function Diagnostic() {
         fontFamily: 'monospace',
         padding: 10,
         overflow: 'auto',
+        height: '100%',
         boxSizing: 'border-box'
       }}
     >


### PR DESCRIPTION
## Summary
- ensure Diagnostic frame fills its container
- make body and html stretch to 100% to enable scrollbars

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_685c8d8b6948832b8e98f0726f97d95c