### PR TITLE
Fix diagnostic lint warning

### DIFF
--- a/src/diagnotic.tsx
+++ b/src/diagnotic.tsx
@@ -112,6 +112,8 @@ function Boot() {
   )
 }
 
+export default Boot
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <Boot />


### PR DESCRIPTION
## Summary
- export the `Boot` component so `diagnotic.tsx` has an export and passes lint

## Testing
- `npm run lint`
- `npm run ok` *(fails: Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_6860ec6a98fc832b97acd812b9a2e05f