### PR TITLE
Handle new getToken prop

### DIFF
--- a/src/types/artifact-client.d.ts
+++ b/src/types/artifact-client.d.ts
@@ -1,0 +1,10 @@
+import '@artifact/client/react'
+
+declare module '@artifact/client/react' {
+  interface ArtifactWebProps {
+    /** Optional replacement for getSecureToken */
+    getToken?: () => Promise<string> | string
+    /** Deprecated in favor of getToken */
+    getSecureToken?: () => Promise<string> | string
+  }
+}


### PR DESCRIPTION
## Summary
- support `getToken` prop in `ArtifactWeb`
- extend ArtifactWeb types for compatibility

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_68630da9026c832b8b103e7e817223e7