### PR TITLE
Handle chat navigate events

### DIFF
--- a/src/chat/chatState.ts
+++ b/src/chat/chatState.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { ChatMessage, Chat, NavigationItem } from '@/shared/types'
+import type { Scope } from '@artifact/client/api'
 import { mockMessages } from '@/shared/mockMessages'
 import { mockChats } from '@/shared/mockChats'
 
@@ -33,6 +34,8 @@ interface ChatActions {
   collapseNavItem: (id: string) => void
   expandNavItem: (id: string) => void
   createNewChat: () => string
+  /** Select a chat by id, creating it if necessary */
+  selectOrCreateChat: (id: string, scope?: Scope) => void
   selectChat: (chatId: string) => void
   setSearchQuery: (query: string) => void
   getFilteredChats: () => Chat[]
@@ -159,6 +162,29 @@ export const useChatStore = create<ChatState & ChatActions>()((set, get) => ({
     }))
 
     return newChatId
+  },
+
+  selectOrCreateChat: (id, scope) => {
+    const existing = get().chats.find((c) => c.id === id)
+    if (!existing) {
+      const newChat: Chat = {
+        id,
+        title: `Chat ${id}`,
+        timestamp: new Date().toISOString(),
+        messageIds: [],
+        scope
+      }
+      set((state) => ({
+        chats: [newChat, ...state.chats],
+        currentChatId: id,
+        isNewEmptyChat: true
+      }))
+    } else {
+      set({
+        currentChatId: id,
+        isNewEmptyChat: existing.messageIds.length === 0
+      })
+    }
   },
 
   selectChat: (chatId) => {

--- a/src/frames/ChatsView.tsx
+++ b/src/frames/ChatsView.tsx
@@ -1,12 +1,34 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import FrameWithDiagnostic from '@/shared/FrameWithDiagnostic'
 import useHomeScope from '@/shared/useHomeScope'
+import { useChatStore } from '@/chat'
+import type { Scope } from '@artifact/client/api'
 
 const ChatsView: React.FC = () => {
   const scope = useHomeScope()
+  const selectOrCreateChat = useChatStore((s) => s.selectOrCreateChat)
+
+  const handleNavigate = useCallback(
+    (target: Scope) => {
+      const chatId =
+        (target as Record<string, string>).fiber ||
+        (target as Record<string, string>).repo ||
+        'unknown'
+      selectOrCreateChat(chatId, target)
+    },
+    [selectOrCreateChat]
+  )
+
   if (!scope) return <div className="p-6">Loading home scope...</div>
 
-  return <FrameWithDiagnostic view="chats" scope={scope} title="Chats" />
+  return (
+    <FrameWithDiagnostic
+      view="chats"
+      scope={scope}
+      title="Chats"
+      onNavigateTo={handleNavigate}
+    />
+  )
 }
 
 export default ChatsView

--- a/src/shared/FrameWithDiagnostic.tsx
+++ b/src/shared/FrameWithDiagnostic.tsx
@@ -13,9 +13,15 @@ interface Props {
   view: View
   scope: Scope
   title: string
+  onNavigateTo?: (scope: Scope) => void
 }
 
-const FrameWithDiagnostic: React.FC<Props> = ({ view, scope, title }) => {
+const FrameWithDiagnostic: React.FC<Props> = ({
+  view,
+  scope,
+  title,
+  onNavigateTo
+}) => {
   const diagnostic = useFrameSrcStore((s) => s.diagnostic)
   const src = useRegularSrc(view)
   const onSelection = useSelectionUpdater()
@@ -26,6 +32,7 @@ const FrameWithDiagnostic: React.FC<Props> = ({ view, scope, title }) => {
         src={src}
         target={scope}
         onSelection={onSelection}
+        onNavigateTo={onNavigateTo}
         title={title}
         className={diagnostic ? 'hidden w-full h-full' : 'w-full h-full'}
       />
@@ -34,6 +41,7 @@ const FrameWithDiagnostic: React.FC<Props> = ({ view, scope, title }) => {
           src={DIAGNOSTIC_PATH}
           target={scope}
           onSelection={onSelection}
+          onNavigateTo={onNavigateTo}
           title="Diagnostic Panel"
           className="w-full h-full"
         />

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,3 +1,5 @@
+import type { Scope } from '@artifact/client/api'
+
 type Role = 'user' | 'assistant' | 'system'
 type MessageType = 'text' | 'navigation' | 'file' | 'code'
 export type View =
@@ -54,6 +56,8 @@ export interface Chat {
   lastMessage?: string
   timestamp: string
   messageIds: string[]
+  /** The associated Artifact scope for this chat */
+  scope?: Scope
 }
 
 interface TranscludePart {


### PR DESCRIPTION
## Summary
- extend `Chat` interface with optional scope info
- add `selectOrCreateChat` to chat store
- wire up chats view to respond to onNavigateTo
- allow frames to pass onNavigateTo to ArtifactHolder

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_686a5acef8a8832bb70d51949e5bbcc9