### PR TITLE
Default target scope to home on first load

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,17 +2,28 @@ import useHashRouter from './useHashRouter'
 import Sidebar from './Sidebar'
 import StateBoard from './StateBoard'
 import { ChatHistory, ChatInput } from '@/chat'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import ChevronLeft from 'lucide-react/dist/esm/icons/chevron-left'
 import ChevronRight from 'lucide-react/dist/esm/icons/chevron-right'
 import { useChat } from '@/chat/useChatHooks'
 import { useChatStore } from '@/chat/chatState'
+import useHomeScope from '@/shared/useHomeScope'
+import { useTargetScopeStore } from '@/shared/targetScope'
 
 function App() {
   useHashRouter()
+  const homeScope = useHomeScope()
+  const currentScope = useTargetScopeStore((s) => s.scope)
+  const setScope = useTargetScopeStore((s) => s.setScope)
   const [showChat, setShowChat] = useState(true)
   const [chatFullscreen, setChatFullscreen] = useState(false)
   const chatId = useChatStore((state) => state.currentChatId)
+
+  useEffect(() => {
+    if (!currentScope && homeScope) {
+      setScope(homeScope)
+    }
+  }, [currentScope, homeScope, setScope])
   return (
     <div className="flex h-screen bg-gray-100">
       <Sidebar />


### PR DESCRIPTION
## Summary
- set the initial target scope to the home scope when the app first loads

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_6874dff746b0832b936e8647f0d21a53