### PR TITLE
Add ephemeral chat creation mode

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,11 +1,10 @@
 import useHashRouter from './useHashRouter'
 import Sidebar from './Sidebar'
 import StateBoard from './StateBoard'
-import { ChatHistory, ChatInput } from '@/chat'
+import Chat from '@/chat/Chat'
 import { useState } from 'react'
 import ChevronLeft from 'lucide-react/dist/esm/icons/chevron-left'
 import ChevronRight from 'lucide-react/dist/esm/icons/chevron-right'
-import { useChat } from '@/chat/useChatHooks'
 import { useChatStore } from '@/chat/chatState'
 
 function App() {
@@ -38,12 +37,12 @@ function App() {
             chatFullscreen ? 'w-full' : showChat ? 'w-2/5' : 'w-0'
           } flex flex-col overflow-hidden bg-white transition-all duration-300 ease-in-out ${showChat ? 'border-r border-gray-200' : ''}`}
         >
-          {showChat && chatId && (
+          {showChat && (
             <Chat
               onToggleFullscreen={() => setChatFullscreen(!chatFullscreen)}
               isFullscreen={chatFullscreen}
               chatId={chatId}
-              key={chatId}
+              key={chatId ?? 'new'}
             />
           )}
         </div>
@@ -63,27 +62,3 @@ function App() {
 }
 
 export default App
-
-interface ChatProps {
-  onToggleFullscreen: () => void
-  isFullscreen: boolean
-  chatId: string
-}
-
-const Chat: React.FC<ChatProps> = ({
-  onToggleFullscreen,
-  isFullscreen,
-  chatId
-}) => {
-  const ai = useChat(chatId)
-  return (
-    <>
-      <ChatHistory
-        onToggleFullscreen={onToggleFullscreen}
-        isFullscreen={isFullscreen}
-        ai={ai}
-      />
-      <ChatInput ai={ai} />
-    </>
-  )
-}

--- a/src/chat/Chat.tsx
+++ b/src/chat/Chat.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect } from 'react'
+import { ChatHistory } from '.'
+import ChatInput from './ChatInput'
+import { useChat } from './useChatHooks'
+import { useChatManagement } from './useChatHooks'
+import { useChatStore } from './chatState'
+import { useExists } from '@artifact/client/hooks'
+
+interface ChatProps {
+  onToggleFullscreen: () => void
+  isFullscreen: boolean
+  chatId: string | undefined
+}
+
+const Chat: React.FC<ChatProps> = ({
+  onToggleFullscreen,
+  isFullscreen,
+  chatId
+}) => {
+  const { newChat } = useChatManagement()
+  const setCurrentChatId = useChatStore((state) => state.setCurrentChatId)
+  const pendingMessage = useChatStore((state) => state.pendingMessage)
+  const setPendingMessage = useChatStore((state) => state.setPendingMessage)
+
+  const chatExists = useExists(chatId ? `chats/${chatId}` : undefined)
+  const valid = chatId && chatExists
+  const ai = useChat(valid ? chatId! : 'new')
+
+  useEffect(() => {
+    if (pendingMessage && valid) {
+      ai.sendMessage({ text: pendingMessage })
+      setPendingMessage(null)
+    }
+  }, [pendingMessage, valid, ai, setPendingMessage])
+
+  const handleSend = async (text: string) => {
+    if (!valid) {
+      const id = await newChat()
+      setPendingMessage(text)
+      setCurrentChatId(id)
+    } else {
+      ai.sendMessage({ text })
+    }
+  }
+
+  return (
+    <>
+      <ChatHistory
+        onToggleFullscreen={onToggleFullscreen}
+        isFullscreen={isFullscreen}
+        ai={ai}
+      />
+      <ChatInput onSendMessage={handleSend} />
+    </>
+  )
+}
+
+export default Chat

--- a/src/chat/ChatInput.tsx
+++ b/src/chat/ChatInput.tsx
@@ -2,11 +2,10 @@ import React, { useState, useRef, useEffect } from 'react'
 import Send from 'lucide-react/dist/esm/icons/send'
 import Paperclip from 'lucide-react/dist/esm/icons/paperclip'
 import Mic from 'lucide-react/dist/esm/icons/mic'
-import { useChat } from './useChatHooks'
-
-const ChatInput: React.FC<{ ai: ReturnType<typeof useChat> }> = ({ ai }) => {
+const ChatInput: React.FC<{ onSendMessage: (text: string) => void }> = ({
+  onSendMessage
+}) => {
   const [message, setMessage] = useState('')
-  const { sendMessage } = ai // TODO provide stop button
   const [isRecording, setIsRecording] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
@@ -24,7 +23,7 @@ const ChatInput: React.FC<{ ai: ReturnType<typeof useChat> }> = ({ ai }) => {
 
   const handleSendMessage = () => {
     if (message.trim()) {
-      sendMessage({ text: message })
+      onSendMessage(message)
       setMessage('')
     }
   }

--- a/src/chat/chatState.ts
+++ b/src/chat/chatState.ts
@@ -4,15 +4,19 @@ import equal from 'fast-deep-equal'
 interface ChatState {
   currentChatId: string | undefined
   setCurrentChatId: (id: string) => void
+  pendingMessage: string | null
+  setPendingMessage: (m: string | null) => void
   // TODO add transclude state in here
 }
 
 export const useChatStore = create<ChatState>()((set, get) => ({
   currentChatId: undefined,
+  pendingMessage: null,
   setCurrentChatId: (id: string) => {
     const current = get().currentChatId
     if (!equal(current, id)) {
       set({ currentChatId: id })
     }
-  }
+  },
+  setPendingMessage: (m: string | null) => set({ pendingMessage: m })
 }))


### PR DESCRIPTION
## Summary
- extract `Chat` component from `App.tsx`
- add ephemeral chat creation when no chat selected or missing
- update `ChatInput` to accept a callback
- extend chat store with pending message handling

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_6874ac3a1ecc832ba1d46b69d3563eef