### PR TITLE
Handle empty reasoning ticks

### DIFF
--- a/src/chat/ChatMessage.tsx
+++ b/src/chat/ChatMessage.tsx
@@ -73,7 +73,12 @@ const ChatMessage: React.FC<ChatMessageProps> = ({ message }) => {
   ) as Array<{ type: 'reasoning'; text: string; state?: 'streaming' | 'done' }>
 
   const textContent = textParts.map((p) => p.text).join('')
-  const reasoningContent = reasoningParts.map((p) => p.text).join('')
+  const reasoningContent = reasoningParts
+    .map((p) => {
+      const trimmed = p.text.trim()
+      return trimmed === 'Thinking...' ? '(empty reasoning tick)' : trimmed
+    })
+    .join('\n')
 
   const isStreaming =
     textParts.some((p) => p.state === 'streaming') ||


### PR DESCRIPTION
## Summary
- interpret `Thinking...` as an empty reasoning step
- show each reasoning part on a new line with placeholder text

## Testing
- `npm run format`
- `npm run ok`


------
https://chatgpt.com/codex/tasks/task_e_68759cf65d40832bb57e1e4678f94167