### PR TITLE
Fix chat hook initialization

### DIFF
--- a/src/chat/Chat.tsx
+++ b/src/chat/Chat.tsx
@@ -23,8 +23,8 @@ const Chat: React.FC<ChatProps> = ({
   const setPendingMessage = useChatStore((state) => state.setPendingMessage)
 
   const chatExists = useExists(chatId ? `chats/${chatId}` : undefined)
+  const ai = useChat(chatId ?? 'new')
   const valid = chatId && chatExists
-  const ai = useChat(valid ? chatId! : 'new')
 
   useEffect(() => {
     if (pendingMessage && valid) {


### PR DESCRIPTION
## Summary
- avoid passing temporary chat id

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_68759fdbc814832ba19ccc5e6415147d