### PR TITLE
Fix reasoning placeholder detection

### DIFF
--- a/src/chat/ChatMessage.tsx
+++ b/src/chat/ChatMessage.tsx
@@ -73,10 +73,13 @@ const ChatMessage: React.FC<ChatMessageProps> = ({ message }) => {
   ) as Array<{ type: 'reasoning'; text: string; state?: 'streaming' | 'done' }>
 
   const textContent = textParts.map((p) => p.text).join('')
+  const isEmptyReasoning = (text: string) =>
+    /^((Thinking\.\.\.\s*)+)$/i.test(text)
+
   const reasoningContent = reasoningParts
     .map((p) => {
       const trimmed = p.text.trim()
-      return trimmed === 'Thinking...' ? '(empty reasoning tick)' : trimmed
+      return isEmptyReasoning(trimmed) ? '(empty reasoning tick)' : trimmed
     })
     .join('\n')
 


### PR DESCRIPTION
## Summary
- treat repeated `Thinking...` placeholders in chat reasoning as empty

## Testing
- `npm run format:check`
- `npm run type-check`
- `npm run lint`
- `npm run build`
- `npm test --if-present`
- `npm run ok`


------
https://chatgpt.com/codex/tasks/task_e_6875a07be0c8832ba04f05eb4607a406