### PR TITLE
Fix chat history perf

### DIFF
--- a/src/chat/ChatMessage.tsx
+++ b/src/chat/ChatMessage.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import equal from 'fast-deep-equal'
 import Loader2 from 'lucide-react/dist/esm/icons/loader-2'
 import type { UIMessage } from '@ai-sdk/react'
 import parseHtml from 'html-react-parser'
@@ -59,7 +60,7 @@ const CodeBlock: LLMOutputComponent = ({ blockMatch }) => {
   return <>{parseHtml(html)}</>
 }
 
-const ChatMessage: React.FC<ChatMessageProps> = ({ message }) => {
+const ChatMessageComponent: React.FC<ChatMessageProps> = ({ message }) => {
   const isUser = message.role === 'user'
 
   const textParts = message.parts.filter((p) => p.type === 'text') as Array<{
@@ -134,5 +135,9 @@ const ChatMessage: React.FC<ChatMessageProps> = ({ message }) => {
     </div>
   )
 }
+
+const ChatMessage = React.memo(ChatMessageComponent, (prev, next) =>
+  equal(prev.message, next.message)
+)
 
 export default ChatMessage


### PR DESCRIPTION
## Summary
- memoize `ChatMessage` component with a deep comparison to avoid rerendering when messages don't change

## Testing
- `npm run ok`


------
https://chatgpt.com/codex/tasks/task_e_6875ce12563c832bb2f1324a38ff7399