### PR TITLE
Fix chat input visibility with scrolling

### DIFF
--- a/src/chat/Chat.tsx
+++ b/src/chat/Chat.tsx
@@ -47,7 +47,7 @@ const Chat: React.FC<ChatProps> = ({
   )
 
   return (
-    <>
+    <div className="flex flex-col h-full">
       <ChatHistory
         onToggleFullscreen={onToggleFullscreen}
         isFullscreen={isFullscreen}
@@ -55,7 +55,7 @@ const Chat: React.FC<ChatProps> = ({
         messages={messages}
       />
       <ChatInput onSendMessage={handleSend} />
-    </>
+    </div>
   )
 }
 

--- a/src/chat/ChatHistory.tsx
+++ b/src/chat/ChatHistory.tsx
@@ -121,7 +121,7 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
   // const timelineItems = getTimelineItems()
 
   return (
-    <div className="flex flex-col h-full bg-gray-50">
+    <div className="flex flex-col flex-1 bg-gray-50">
       <div className="bg-white border-b border-gray-200 px-4 py-2 pl-12">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">

--- a/src/chat/ChatInput.tsx
+++ b/src/chat/ChatInput.tsx
@@ -40,7 +40,7 @@ const ChatInput: React.FC<{ onSendMessage: (text: string) => void }> = ({
   }
 
   return (
-    <div className="bg-white border-t border-gray-200 p-4">
+    <div className="bg-white border-t border-gray-200 p-4 flex-shrink-0">
       {isRecording && (
         <div className="mt-2 text-center text-sm text-red-500 animate-pulse">
           Recording... (Click mic to stop)


### PR DESCRIPTION
## Summary
- ensure ChatHistory doesn't overtake entire container by using `flex-1`
- keep ChatInput from shrinking and wrap Chat components in a flex container

## Testing
- `npm run format`
- `npm run ok`


------
https://chatgpt.com/codex/tasks/task_e_6877382c7c24832bb1873083eed53780