### PR TITLE
Virtualize chat history with react-virtuoso

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,10 +27,10 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
+        "react-virtuoso": "^4.13.0",
         "remark-gfm": "^4.0.1",
         "rfc6902": "^5.1.2",
         "shiki": "^3.8.0",
-        "use-stick-to-bottom": "^1.1.1",
         "zustand": "^5.0.6"
       },
       "devDependencies": {
@@ -10333,6 +10333,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-virtuoso": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-4.13.0.tgz",
+      "integrity": "sha512-XHv2Fglpx80yFPdjZkV9d1baACKghg/ucpDFEXwaix7z0AfVQj+mF6lM+YQR6UC/TwzXG2rJKydRMb3+7iV3PA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16 || >=17 || >= 18 || >= 19",
+        "react-dom": ">=16 || >=17 || >= 18 || >=19"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -11602,15 +11612,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/use-stick-to-bottom": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/use-stick-to-bottom/-/use-stick-to-bottom-1.1.1.tgz",
-      "integrity": "sha512-JkDp0b0tSmv7HQOOpL1hT7t7QaoUBXkq045WWWOFDTlLGRzgIIyW7vyzOIJzY7L2XVIG7j1yUxeDj2LHm9Vwng==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
+    "react-virtuoso": "^4.13.0",
     "remark-gfm": "^4.0.1",
     "rfc6902": "^5.1.2",
     "shiki": "^3.8.0",
-    "use-stick-to-bottom": "^1.1.1",
     "zustand": "^5.0.6"
   },
   "devDependencies": {

--- a/src/chat/ChatHistory.tsx
+++ b/src/chat/ChatHistory.tsx
@@ -9,7 +9,7 @@ import Search from 'lucide-react/dist/esm/icons/search'
 import Plus from 'lucide-react/dist/esm/icons/plus'
 import Maximize2 from 'lucide-react/dist/esm/icons/maximize-2'
 import Minimize2 from 'lucide-react/dist/esm/icons/minimize-2'
-import { useStickToBottom } from 'use-stick-to-bottom'
+import { Virtuoso } from 'react-virtuoso'
 
 // import { ChatMessage as ChatMessageType, NavigationItem } from '@/shared/types'
 import { useChatManagement, UIMessage } from './useChatHooks'
@@ -34,7 +34,7 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
   messages
 }) => {
   // const messagesEndRef = React.useRef<HTMLDivElement>(null)
-  const { scrollRef, contentRef } = useStickToBottom()
+  // react-virtuoso handles sticking to bottom automatically
   const { newChat } = useChatManagement()
 
   const setCurrentChatId = useChatStore((state) => state.setCurrentChatId)
@@ -163,7 +163,7 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
       </div>
 
       {/* Chat Messages */}
-      <div className="flex-1 overflow-y-auto" ref={scrollRef}>
+      <div className="flex-1 overflow-y-auto">
         {pendingChatId && !chatExists ? (
           <div className="flex-1 flex items-center justify-center h-full">
             <div className="text-center">
@@ -182,13 +182,22 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
             </div>
           </div>
         ) : (
-          <div className="py-4 px-6">
-            <div className="space-y-4" ref={contentRef}>
-              {messages.map((item) => (
-                <ChatMessage key={item.id} message={item} />
-              ))}
-            </div>
-          </div>
+          <Virtuoso
+            className="flex-1"
+            style={{ height: '100%' }}
+            data={messages}
+            followOutput="smooth"
+            itemContent={(_, item) => <ChatMessage message={item} />}
+            components={{
+              List: React.forwardRef((props, ref) => (
+                <div
+                  {...props}
+                  ref={ref as React.Ref<HTMLDivElement>}
+                  className="space-y-4 py-4 px-6"
+                />
+              ))
+            }}
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- use `react-virtuoso` to virtualize messages in `ChatHistory`
- remove `use-stick-to-bottom` dependency
- install `react-virtuoso`

## Testing
- `npm run ok`

------
https://chatgpt.com/codex/tasks/task_e_687833ee42b4832ba9623cdab5118ac4